### PR TITLE
fix i9305

### DIFF
--- a/src/droid/droid-util.c
+++ b/src/droid/droid-util.c
@@ -752,7 +752,7 @@ static void add_o_ports(pa_droid_mapping *am) {
 
         if (devices & cur_device) {
 
-            pa_assert_se(pa_droid_output_port_name(cur_device, &name));
+            pa_droid_output_port_name(cur_device, &name);
 
             if (!(p = pa_hashmap_get(am->profile_set->all_ports, name))) {
 
@@ -769,7 +769,7 @@ static void add_o_ports(pa_droid_mapping *am) {
 
     /* Combo devices, route to multiple routing targets simultaneously. */
     if (am->output->devices & combo_devices) {
-        pa_assert_se(pa_droid_output_port_name(combo_devices, &name));
+        pa_droid_output_port_name(combo_devices, &name);
         if (!(p = pa_hashmap_get(am->profile_set->all_ports, name))) {
             p = create_o_port(am, combo_devices, name, NULL);
             /* Reset priority to default. */
@@ -783,6 +783,7 @@ static void add_o_ports(pa_droid_mapping *am) {
     }
 
     if (!(p = pa_hashmap_get(am->profile_set->all_ports, PA_DROID_OUTPUT_PARKING))) {
+        pa_log_debug("  New output port %s", PA_DROID_OUTPUT_PARKING);
         /* Create parking port for output mapping to be used when audio_mode_t changes. */
         p = create_o_port(am, 0, PA_DROID_OUTPUT_PARKING, "Parking port");
         /* Reset priority to half of default */
@@ -814,7 +815,7 @@ static void add_i_ports(pa_droid_mapping *am) {
 
         if (devices & cur_device) {
 
-            pa_assert_se(pa_droid_input_port_name(cur_device, &name));
+            pa_droid_input_port_name(cur_device, &name);
 
             if (!(p = pa_hashmap_get(am->profile_set->all_ports, name))) {
                 pa_log_debug("  New input port %s", name);


### PR DESCRIPTION
This reverts commit 140fbea03f67558095474ed67151c5fd3c1a510a.

There is some bug in source port lookup with i9305 hal headers,
which results in bad ports. but doesn't prevent sink usage.
