### PR TITLE
[droid-sink] Workaround use OUT_SPEAKER as default device.

### DIFF
--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -835,7 +835,9 @@ pa_sink *pa_droid_sink_new(pa_module *m,
     };
 
     /* Default routing */
-    dev_out = AUDIO_DEVICE_OUT_DEFAULT;
+    /* dev_out = AUDIO_DEVICE_OUT_DEFAULT; */
+    /* FIXME use something else than OUT_DEFAULT for i9305 to get initial audio working. */
+    dev_out = AUDIO_DEVICE_OUT_SPEAKER;
 
     if ((tmp = pa_modargs_get_value(ma, "output_devices", NULL))) {
         audio_devices_t tmp_dev;


### PR DESCRIPTION
AUDIO_DEVICE_OUT_DEFAULT is defined as AUDIO_DEVICE_BIT_DEFAULT instead
of real output device. Use OUT_SPEAKER as default output so that default
opens working routing.
