### PR TITLE
[util-44] process DRC tags only for Android >=4.4 versions

### DIFF
--- a/src/droid/droid-util-44.h
+++ b/src/droid/droid-util-44.h
@@ -24,6 +24,9 @@
 
 #define HAL_V2
 
+// Android v4.4 has SPEAKER_DRC_ENABLED_TAG, so might the future versions
+#define DROID_HAVE_DRC
+
 #ifdef DROID_DEVICE_HAMMERHEAD
 #define QCOM_HARDWARE
 #endif

--- a/src/droid/droid-util.c
+++ b/src/droid/droid-util.c
@@ -457,8 +457,8 @@ bool pa_parse_droid_audio_config(const char *filename, pa_droid_config_audio *co
                 success = parse_devices(val, true, &config->global_config.default_output_device);
             else if (pa_streq(v, ATTACHED_INPUT_DEVICES_TAG))
                 success = parse_devices(val, false, &config->global_config.attached_input_devices);
-#ifdef HAL_V2
-            // SPEAKER_DRC_ENABLED_TAG is only from HAL v2
+#ifdef DROID_HAVE_DRC
+            // SPEAKER_DRC_ENABLED_TAG is only from Android v4.4
             else if (pa_streq(v, SPEAKER_DRC_ENABLED_TAG))
                 /* TODO - Add support for dynamic range control */
                 success = true; /* Do not fail while parsing speaker_drc_enabled entry */


### PR DESCRIPTION
Checking against HAL_V2 is unreliable, because Android v4.2 also has
HAL_V2 defined, yet does not contain SPEAKER_DRC_ENABLED_TAG
