### PR TITLE
[card] Remove redundant includes to fix the order of #defines

### DIFF
--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -55,9 +55,6 @@
 #include <pulsecore/device-port.h>
 #include <pulsecore/idxset.h>
 
-#include <hardware/audio.h>
-#include <system/audio.h>
-
 //#include <droid/hardware/audio_policy.h>
 //#include <droid/system/audio_policy.h>
 


### PR DESCRIPTION
Removing the redundant includes fixes including system/audio.h in droid-util-44.h when QCOM_HARDWARE is defined. Before this change the include of system/audio.h happens here without QCOM_HARDWARE defined and therefore prevents using anything with QCOM_HARDWARE condition from system/audio.h in droid-util-44.h where system/audio.h is included after conditional definition of QCOM_HARDWARE.