### PR TITLE
Fix audio on iyokan.

### DIFF
--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -121,7 +121,7 @@ static int do_routing(struct userdata *u, audio_devices_t devices) {
 
     pa_log_debug("set_parameters(%s) %s : %#010x", setparam, devlist, devices);
 
-#ifdef DROID_DEVICE_MAKO
+#if defined(DROID_DEVICE_MAKO) || defined(DROID_DEVICE_IYOKAN)
 #warning Using mako set_parameters hack.
     ret = u->card_data->set_parameters(u->card_data, setparam);
 #else

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -212,6 +212,7 @@ static void thread_func(void *userdata) {
     struct userdata *u = userdata;
 
     pa_assert(u);
+    pa_assert(u->stream);
 
     pa_log_debug("Thread starting up.");
 
@@ -221,6 +222,8 @@ static void thread_func(void *userdata) {
     pa_thread_mq_install(&u->thread_mq);
 
     u->timestamp = pa_rtclock_now();
+
+    u->stream->common.standby(&u->stream->common);
 
     for (;;) {
         int ret;


### PR DESCRIPTION
First patch enables the mako set_parameters hack on iyokan to prevent failure. Second patch sets input stream to standby before starting the actual source thread loop to prevent hanging when reading from the stream due to insufficient initialization. On some devices the actual initialization is done in read(...) only when the stream is in standby. The same is done also in Android audioflinger (https://github.com/CyanogenMod/android_frameworks_av/blob/cm-11.0/services/audioflinger/Threads.cpp#L4838).