### PR TITLE
Make attached devices parsing more tolerant of unknown devices.

### DIFF
--- a/src/droid/droid-util.c
+++ b/src/droid/droid-util.c
@@ -599,13 +599,13 @@ bool pa_parse_droid_audio_config(const char *filename, pa_droid_config_audio *co
 
                 if (pa_streq(v, ATTACHED_OUTPUT_DEVICES_TAG))
                     success = parse_devices(filename, n, value, true,
-                                            &config->global_config.attached_output_devices, true);
+                                            &config->global_config.attached_output_devices, false);
                 else if (pa_streq(v, DEFAULT_OUTPUT_DEVICE_TAG))
                     success = parse_devices(filename, n, value, true,
                                             &config->global_config.default_output_device, true);
                 else if (pa_streq(v, ATTACHED_INPUT_DEVICES_TAG))
                     success = parse_devices(filename, n, value, false,
-                                            &config->global_config.attached_input_devices, true);
+                                            &config->global_config.attached_input_devices, false);
 #ifdef DROID_HAVE_DRC
                 // SPEAKER_DRC_ENABLED_TAG is only from Android v4.4
                 else if (pa_streq(v, SPEAKER_DRC_ENABLED_TAG))


### PR DESCRIPTION
Previously no unknown devices in attached sections were allowed.
Output and input sections already allow for unknown devices as long as
at least one known device is found per section. This changes attached
devices parsing to behave the same way, as long as at least one device
in attached_input_devices or attached_output_devices is known allow
module loading.