### PR TITLE
Make microphone and other sources work in Xiaomi Redmi 1S (armani) device

### DIFF
--- a/src/common/droid-util-44.h
+++ b/src/common/droid-util-44.h
@@ -90,7 +90,7 @@ uint32_t conversion_table_format[][2] = {
 };
 
 uint32_t conversion_table_default_audio_source[][2] = {
-#ifdef DROID_DEVICE_HAMMERHEAD
+#if defined(DROID_DEVICE_HAMMERHEAD) || defined(DROID_DEVICE_ARMANI)
     { AUDIO_DEVICE_IN_COMMUNICATION,                AUDIO_SOURCE_MIC },
     { AUDIO_DEVICE_IN_AMBIENT,                      AUDIO_SOURCE_MIC },
     { AUDIO_DEVICE_IN_BUILTIN_MIC,                  AUDIO_SOURCE_MIC },


### PR DESCRIPTION
Fixes following errors in dmesg 
> MSM8226 Media1: asoc: MSM8226 Media1 no valid capture route from source to sink

and in logcat

> D/audio_hw_primary( 1064): start_input_stream: exit: status(-5)
> D/audio_hw_primary( 1064): in_standby: enter: stream (0x116a150) usecase(7: audio-record)
> D/audio_hw_primary( 1064): start_input_stream: enter: stream(0x116a150)usecase(7: audio-record)
> E/audio_hw_primary( 1064): start_input_stream: cannot open device '/dev/snd/pcmC0D0c': Invalid argument
> E/audio_hw_primary( 1064): disable_snd_device: Invalid sound device 0