### PR TITLE
[card] Use pa_card_put for PulseAudio 8.0

### DIFF
--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -903,6 +903,10 @@ int pa__init(pa_module *m) {
     u->card->userdata = u;
     u->card->set_profile = card_set_profile;
 
+#if (PULSEAUDIO_VERSION >= 8)
+    pa_card_put(u->card);
+#endif
+
     u->modargs = ma;
     u->module = m;
 


### PR DESCRIPTION
In PulseAudio 8.0, profile selection has been moved to pa_card_put, which now needs to be called in addition to pa_card_new.

See https://patchwork.freedesktop.org/patch/62759/ for details.