### PR TITLE
Only refresh input routing if forced.

### DIFF
--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -98,8 +98,12 @@ static int do_routing(struct userdata *u, audio_devices_t devices, bool force) {
         return 0;
     }
 
-    if (u->primary_devices == devices)
-        pa_log_debug("Refresh active device routing.");
+    if (u->primary_devices == devices) {
+        if (force)
+            pa_log_debug("Refresh active device routing.");
+        else
+            return 0;
+    }
 
     old_device = u->primary_devices;
     u->primary_devices = devices;


### PR DESCRIPTION
Unless the routing is forced do not refresh routing. With output routing
it is necessary to refresh the routing when changing audio mode, but
input routing doesn't have similar requirement. Also on some devices
setting identical input routing blocks thread for a while. Due to this
disable input route refreshing for most cases.