### PR TITLE
Extend config parser.

### DIFF
--- a/src/common/droid-util.h
+++ b/src/common/droid-util.h
@@ -130,6 +130,7 @@ struct pa_droid_card_data {
 #define AUDIO_MAX_SAMPLING_RATES (32)
 
 typedef struct pa_droid_config_global {
+    uint32_t audio_hal_version;
     audio_devices_t attached_output_devices;
     audio_devices_t default_output_device;
     audio_devices_t attached_input_devices;
@@ -167,6 +168,8 @@ struct pa_droid_config_hw_module {
     const pa_droid_config_audio *config;
 
     char *name;
+    /* If global config is not defined for module, use root global config. */
+    pa_droid_config_global *global_config;
     pa_droid_config_output *outputs;
     pa_droid_config_input *inputs;
 
@@ -174,7 +177,7 @@ struct pa_droid_config_hw_module {
 };
 
 struct pa_droid_config_audio {
-    pa_droid_config_global global_config;
+    pa_droid_config_global *global_config;
     pa_droid_config_hw_module *hw_modules;
 };
 

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -1177,7 +1177,8 @@ pa_sink *pa_droid_sink_new(pa_module *m,
     }
 
     /* Default routing */
-    dev_out = u->hw_module->config->global_config.default_output_device;
+    dev_out = am->output->module->global_config ? am->output->module->global_config->default_output_device
+                                                : u->hw_module->config->global_config->default_output_device;
 
     if ((tmp = pa_modargs_get_value(ma, "output_devices", NULL))) {
         audio_devices_t tmp_dev;


### PR DESCRIPTION
New audio_policy.conf files contain new sections with new values as well
as global_configuration section per-module.

Currently other than using per-module global_configuration we ignore all
the values, but extend the parser so that when the new config values are
needed it's easier to parse them.