### PR TITLE
Update droid source's input stream handling.

### DIFF
--- a/src/common/droid-util-audio.h
+++ b/src/common/droid-util-audio.h
@@ -108,10 +108,13 @@ uint32_t conversion_table_default_audio_source[][2] = {
 #if defined(HAVE_ENUM_AUDIO_DEVICE_IN_FM_RX) && defined(HAVE_ENUM_AUDIO_SOURCE_FM_RX)
     { AUDIO_DEVICE_IN_FM_RX,                        AUDIO_SOURCE_FM_RX                      },
 #endif
+#if defined(HAVE_ENUM_AUDIO_DEVICE_IN_FM_TUNER) && defined(HAVE_ENUM_AUDIO_SOURCE_FM_TUNER)
+    { AUDIO_DEVICE_IN_FM_TUNER,                     AUDIO_SOURCE_FM_TUNER                   },
+#endif
 #if defined(HAVE_ENUM_AUDIO_DEVICE_IN_FM_RX_A2DP) && defined(HAVE_ENUM_AUDIO_SOURCE_FM_RX_A2DP)
     { AUDIO_DEVICE_IN_FM_RX_A2DP,                   AUDIO_SOURCE_FM_RX_A2DP                 },
 #endif
-    { AUDIO_DEVICE_IN_ALL,                          AUDIO_SOURCE_DEFAULT }
+    { AUDIO_DEVICE_IN_ALL,                          AUDIO_SOURCE_DEFAULT                    }
 };
 
 /* Output devices */

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -2409,3 +2409,17 @@ bool pa_sink_is_droid_sink(pa_sink *s) {
     else
         return false;
 }
+
+size_t pa_droid_buffer_size_round_up(size_t buffer_size, size_t block_size) {
+    size_t r;
+
+    pa_assert(buffer_size);
+    pa_assert(block_size);
+
+    r = buffer_size % block_size;
+
+    if (r)
+        return buffer_size + block_size - r;
+
+    return buffer_size;
+}

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -1565,14 +1565,21 @@ void pa_droid_add_card_ports(pa_card_profile *cp, pa_hashmap *ports, pa_droid_ma
     add_ports(core, cp, ports, am, NULL);
 }
 
-static void log_active_quirks(pa_droid_quirks *quirks) {
+void pa_droid_quirk_log(pa_droid_hw_module *hw) {
     uint32_t i;
 
-    if (quirks) {
-        pa_log_debug("Enabled quirks:");
-        for (i = 0; i < sizeof(valid_quirks) / sizeof(struct droid_quirk); i++)
-            if (quirks->enabled[i])
-                pa_log_debug("  %s", valid_quirks[i].name);
+    pa_assert(hw);
+
+    if (hw->quirks) {
+        for (i = 0; i < sizeof(valid_quirks) / sizeof(struct droid_quirk); i++) {
+            if (hw->quirks->enabled[i]) {
+                pa_log_debug("Enabled quirks:");
+                for (i = 0; i < sizeof(valid_quirks) / sizeof(struct droid_quirk); i++)
+                    if (hw->quirks->enabled[i])
+                        pa_log_debug("  %s", valid_quirks[i].name);
+                return;
+            }
+        }
     }
 }
 
@@ -1604,12 +1611,10 @@ static pa_droid_quirks *set_default_quirks(pa_droid_quirks *q) {
     q = get_quirks(q);
     q->enabled[QUIRK_CLOSE_INPUT] = true;
 
-    log_active_quirks(q);
-
     return q;
 }
 
-bool pa_droid_parse_quirks(pa_droid_hw_module *hw, const char *quirks) {
+bool pa_droid_quirk_parse(pa_droid_hw_module *hw, const char *quirks) {
     char *quirk = NULL;
     char *d;
     const char *state = NULL;
@@ -1642,8 +1647,6 @@ bool pa_droid_parse_quirks(pa_droid_hw_module *hw, const char *quirks) {
 
         pa_xfree(quirk);
     }
-
-    log_active_quirks(hw->quirks);
 
     return true;
 

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -2112,6 +2112,9 @@ pa_droid_stream *pa_droid_open_input_stream(pa_droid_hw_module *module,
         goto fail;
     }
 
+    /* we need to call standby before reading with some devices. */
+    stream->common.standby(&stream->common);
+
     s = droid_stream_new(module);
     s->in = stream;
     s->sample_spec = sample_spec;

--- a/src/common/droid-util.h
+++ b/src/common/droid-util.h
@@ -106,7 +106,6 @@ struct pa_droid_hw_module {
     pa_idxset *inputs;
 
     pa_atomic_t active_outputs;
-    uint32_t output_device;
 
     pa_droid_quirks *quirks;
 };
@@ -119,6 +118,8 @@ struct pa_droid_stream {
     pa_sample_spec sample_spec;
     pa_channel_map channel_map;
     uint32_t flags;
+    uint32_t device;
+    audio_source_t audio_source;
 
     struct audio_stream_out *out;
     struct audio_stream_in *in;
@@ -374,6 +375,8 @@ int pa_droid_stream_set_input_route(pa_droid_stream *s, audio_devices_t device, 
 bool pa_droid_stream_is_primary(pa_droid_stream *s);
 
 int pa_droid_stream_suspend(pa_droid_stream *s, bool suspend);
+
+size_t pa_droid_stream_buffer_size(pa_droid_stream *s);
 
 static inline int pa_droid_output_stream_any_active(pa_droid_stream *s) {
     return pa_atomic_load(&s->module->active_outputs);

--- a/src/common/droid-util.h
+++ b/src/common/droid-util.h
@@ -397,6 +397,10 @@ static inline int pa_droid_output_stream_any_active(pa_droid_stream *s) {
     return pa_atomic_load(&s->module->active_outputs);
 }
 
+static inline ssize_t pa_droid_stream_write(pa_droid_stream *stream, const void *buffer, size_t bytes) {
+    return stream->out->write(stream->out, buffer, bytes);
+}
+
 bool pa_sink_is_droid_sink(pa_sink *s);
 
 /* Misc */

--- a/src/common/droid-util.h
+++ b/src/common/droid-util.h
@@ -384,4 +384,7 @@ static inline int pa_droid_output_stream_any_active(pa_droid_stream *s) {
 
 bool pa_sink_is_droid_sink(pa_sink *s);
 
+/* Misc */
+size_t pa_droid_buffer_size_round_up(size_t buffer_size, size_t block_size);
+
 #endif

--- a/src/common/droid-util.h
+++ b/src/common/droid-util.h
@@ -282,8 +282,9 @@ void pa_droid_hw_module_lock(pa_droid_hw_module *hw);
 bool pa_droid_hw_module_try_lock(pa_droid_hw_module *hw);
 void pa_droid_hw_module_unlock(pa_droid_hw_module *hw);
 
-bool pa_droid_parse_quirks(pa_droid_hw_module *hw, const char *quirks);
+bool pa_droid_quirk_parse(pa_droid_hw_module *hw, const char *quirks);
 bool pa_droid_quirk(pa_droid_hw_module *hw, enum pa_droid_quirk_type quirk);
+void pa_droid_quirk_log(pa_droid_hw_module *hw);
 
 /* Conversion helpers */
 typedef enum {

--- a/src/common/droid-util.h
+++ b/src/common/droid-util.h
@@ -82,6 +82,13 @@ typedef struct pa_droid_config_hw_module pa_droid_config_hw_module;
 
 typedef struct pa_droid_quirks pa_droid_quirks;
 
+typedef enum pa_droid_hook {
+    PA_DROID_HOOK_INPUT_CHANNEL_MAP_CHANGED,    /* Call data: pa_droid_stream */
+    PA_DROID_HOOK_INPUT_BUFFER_SIZE_CHANGED,    /* Call data: pa_droid_stream */
+    PA_DROID_HOOK_MAX
+} pa_droid_hook_t;
+
+
 struct pa_droid_hw_module {
     PA_REFCNT_DECLARE;
 
@@ -108,6 +115,7 @@ struct pa_droid_hw_module {
     pa_atomic_t active_outputs;
 
     pa_droid_quirks *quirks;
+    pa_hook hooks[PA_DROID_HOOK_MAX];
 };
 
 struct pa_droid_stream {
@@ -117,9 +125,11 @@ struct pa_droid_stream {
 
     pa_sample_spec sample_spec;
     pa_channel_map channel_map;
+    pa_sample_spec input_sample_spec;
+    pa_channel_map input_channel_map;
     uint32_t flags;
     uint32_t device;
-    audio_source_t audio_source;
+    size_t buffer_size;
 
     struct audio_stream_out *out;
     struct audio_stream_in *in;
@@ -256,6 +266,7 @@ struct pa_droid_profile_set {
 enum pa_droid_quirk_type {
     QUIRK_INPUT_ATOI,
     QUIRK_SET_PARAMETERS,
+    QUIRK_CLOSE_INPUT,
     QUIRK_COUNT
 };
 
@@ -340,6 +351,8 @@ bool pa_droid_input_port_name(audio_devices_t value, const char **to_str);
 
 /* Pretty audio source names */
 bool pa_droid_audio_source_name(audio_source_t value, const char **to_str);
+
+pa_hook *pa_droid_hooks(pa_droid_hw_module *hw);
 
 /* Module operations */
 int pa_droid_set_parameters(pa_droid_hw_module *hw, const char *parameters);

--- a/src/common/droid-util.h
+++ b/src/common/droid-util.h
@@ -401,6 +401,10 @@ static inline ssize_t pa_droid_stream_write(pa_droid_stream *stream, const void 
     return stream->out->write(stream->out, buffer, bytes);
 }
 
+static inline ssize_t pa_droid_stream_read(pa_droid_stream *stream, void *buffer, size_t bytes) {
+    return stream->in->read(stream->in, buffer, bytes);
+}
+
 bool pa_sink_is_droid_sink(pa_sink *s);
 
 /* Misc */

--- a/src/common/droid-util.h
+++ b/src/common/droid-util.h
@@ -370,20 +370,22 @@ pa_droid_stream *pa_droid_open_output_stream(pa_droid_hw_module *module,
                                              audio_output_flags_t flags,
                                              audio_devices_t devices);
 
-/* Set routing to the output stream, with following side-effects:
+/* Set routing to the input or output stream, with following side-effects:
+ * Output:
  * - if routing is set to primary output stream, set routing to all other
  *   open streams as well
  * - if routing is set to non-primary stream and primary stream exists, do nothing
  * - if routing is set to non-primary stream and primary stream doesn't exist, set routing
+ * Input:
+ * - buffer size or channel count may change
  */
-int pa_droid_stream_set_output_route(pa_droid_stream *s, audio_devices_t device);
+int pa_droid_stream_set_route(pa_droid_stream *s, audio_devices_t device);
 
 /* Input stream operations */
 pa_droid_stream *pa_droid_open_input_stream(pa_droid_hw_module *module,
                                             const pa_sample_spec *spec,
                                             const pa_channel_map *map,
                                             audio_devices_t devices);
-int pa_droid_stream_set_input_route(pa_droid_stream *s, audio_devices_t device, audio_source_t *new_source);
 
 bool pa_droid_stream_is_primary(pa_droid_stream *s);
 

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -213,7 +213,7 @@ static void do_routing(struct userdata *u) {
 
     routing = u->primary_devices | u->extra_devices;
 
-    pa_droid_stream_set_output_route(u->stream, routing);
+    pa_droid_stream_set_route(u->stream, routing);
 }
 
 static bool parse_device_list(const char *str, audio_devices_t *dst) {

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -1201,17 +1201,10 @@ pa_sink *pa_droid_sink_new(pa_module *m,
 
     u->buffer_size = pa_droid_stream_buffer_size(u->stream);
     if (sink_buffer) {
-        if (sink_buffer < u->buffer_size)
-            pa_log_warn("Requested buffer size %u less than HAL reported buffer size (%u).", sink_buffer, u->buffer_size);
-        else if (sink_buffer % u->buffer_size) {
-            uint32_t trunc = (sink_buffer / u->buffer_size) * u->buffer_size;
-            pa_log_warn("Requested buffer size %u not multiple of HAL buffer size (%u). Using buffer size %u", sink_buffer, u->buffer_size, trunc);
-            u->buffer_size = trunc;
-        } else {
-            pa_log_info("Using requested buffer size %u.", sink_buffer);
-            u->buffer_size = sink_buffer;
-        }
-    }
+        u->buffer_size = pa_droid_buffer_size_round_up(sink_buffer, u->buffer_size);
+        pa_log_info("Using buffer size %u (requested %u).", u->buffer_size, sink_buffer);
+    } else
+        pa_log_info("Using buffer size %u.", u->buffer_size);
 
     if ((prewrite_resume = pa_modargs_get_value(ma, "prewrite_on_resume", NULL))) {
         if (!parse_prewrite_on_resume(u, prewrite_resume, am ? am->output->name : module_id)) {

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -255,7 +255,7 @@ static int thread_write_silence(struct userdata *u) {
      * here it's okay, as long as mute time isn't configured too strictly. */
 
     p = pa_memblock_acquire(u->silence.memblock);
-    wrote = u->stream->out->write(u->stream->out, (const uint8_t*) p + u->silence.index, u->silence.length);
+    wrote = pa_droid_stream_write(u->stream, (const uint8_t *) p + u->silence.index, u->silence.length);
     pa_memblock_release(u->silence.memblock);
 
     u->write_time = pa_rtclock_now() - u->write_time;
@@ -280,7 +280,7 @@ static int thread_write(struct userdata *u) {
 
     for (;;) {
         p = pa_memblock_acquire(c.memblock);
-        wrote = u->stream->out->write(u->stream->out, (const uint8_t*) p + c.index, c.length);
+        wrote = pa_droid_stream_write(u->stream, (const uint8_t *) p + c.index, c.length);
         pa_memblock_release(c.memblock);
 
         if (wrote < 0) {

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -1199,7 +1199,7 @@ pa_sink *pa_droid_sink_new(pa_module *m,
         goto fail;
     }
 
-    u->buffer_size = u->stream->out->common.get_buffer_size(&u->stream->out->common);
+    u->buffer_size = pa_droid_stream_buffer_size(u->stream);
     if (sink_buffer) {
         if (sink_buffer < u->buffer_size)
             pa_log_warn("Requested buffer size %u less than HAL reported buffer size (%u).", sink_buffer, u->buffer_size);

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -96,7 +96,6 @@ static void userdata_free(struct userdata *u);
 static int do_routing(struct userdata *u, audio_devices_t devices, bool force) {
     int ret;
     audio_devices_t old_device;
-    audio_source_t source;
 
     pa_assert(u);
     pa_assert(u->stream);
@@ -116,7 +115,7 @@ static int do_routing(struct userdata *u, audio_devices_t devices, bool force) {
     old_device = u->primary_devices;
     u->primary_devices = devices;
 
-    ret = pa_droid_stream_set_input_route(u->stream, devices, &source);
+    ret = pa_droid_stream_set_route(u->stream, devices);
 
     if (ret < 0)
         u->primary_devices = old_device;

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -198,8 +198,6 @@ static void thread_func(void *userdata) {
 
     u->timestamp = pa_rtclock_now();
 
-    u->stream->in->common.standby(&u->stream->in->common);
-
     for (;;) {
         int ret;
 

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -157,7 +157,7 @@ static int thread_read(struct userdata *u) {
     chunk.memblock = pa_memblock_new(u->core->mempool, (size_t) u->buffer_size);
 
     p = pa_memblock_acquire(chunk.memblock);
-    readd = u->stream->in->read(u->stream->in, (uint8_t*) p, pa_memblock_get_length(chunk.memblock));
+    readd = pa_droid_stream_read(u->stream, p, pa_memblock_get_length(chunk.memblock));
     pa_memblock_release(chunk.memblock);
 
     if (readd < 0) {

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -577,7 +577,7 @@ pa_source *pa_droid_source_new(pa_module *m,
         goto fail;
     }
 
-    u->buffer_size = u->stream->in->common.get_buffer_size(&u->stream->in->common);
+    u->buffer_size = pa_droid_stream_buffer_size(u->stream);
     if (source_buffer) {
         if (source_buffer < u->buffer_size)
             pa_log_warn("Requested buffer size %u less than HAL reported buffer size (%u).", source_buffer, u->buffer_size);

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -577,17 +577,10 @@ pa_source *pa_droid_source_new(pa_module *m,
 
     u->buffer_size = pa_droid_stream_buffer_size(u->stream);
     if (source_buffer) {
-        if (source_buffer < u->buffer_size)
-            pa_log_warn("Requested buffer size %u less than HAL reported buffer size (%u).", source_buffer, u->buffer_size);
-        else if (source_buffer % u->buffer_size) {
-            uint32_t trunc = (source_buffer / u->buffer_size) * u->buffer_size;
-            pa_log_warn("Requested buffer size %u not multiple of HAL buffer size (%u). Using buffer size %u", source_buffer, u->buffer_size, trunc);
-            u->buffer_size = trunc;
-        } else {
-            pa_log_info("Using requested buffer size %u.", source_buffer);
-            u->buffer_size = source_buffer;
-        }
-    }
+        u->buffer_size = pa_droid_buffer_size_round_up(source_buffer, u->buffer_size);
+        pa_log_info("Using buffer size %u (requested %u).", u->buffer_size, source_buffer);
+    } else
+        pa_log_info("Using buffer size %u.", u->buffer_size);
 
     pa_source_new_data_init(&data);
     data.driver = driver;

--- a/src/droid/droid-source.h
+++ b/src/droid/droid-source.h
@@ -53,7 +53,4 @@ pa_source *pa_droid_source_new(pa_module *m,
                                  pa_card *card);
 void pa_droid_source_free(pa_source *s);
 
-void pa_droid_source_set_routing(pa_source *s, bool enabled);
-int pa_droid_source_set_port(pa_source *s, pa_device_port *p);
-
 #endif

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -749,11 +749,13 @@ int pa__init(pa_module *m) {
         goto fail;
 
     if ((quirks = pa_modargs_get_value(ma, "quirks", NULL))) {
-        if (!pa_droid_parse_quirks(u->hw_module, quirks)) {
+        if (!pa_droid_quirk_parse(u->hw_module, quirks)) {
             pa_log("Failed to parse quirks.");
             goto fail;
         }
     }
+
+    pa_droid_quirk_log(u->hw_module);
 
     u->card_data.set_parameters = set_parameters_cb;
     u->card_data.module_id = pa_xstrdup(module_id);


### PR DESCRIPTION
Previously input stream was opened once when the droid source was created. This causes problems with some HAL implementations, for example audio route may get stuck to whatever was first set. This is probably since on AudioFlinger input streams are always closed when not in use.

Update the droid source implementation to match this more closely. Now we by default always close the input stream when the source is suspending, and if source is active when port change happens, we then also close the stream, set new routes, and reopen the input stream. It is also possible to change this behaviour so that instead of closing the stream during port change the stream is just set to standby.

This change also obsoletes voicecall-record profile in droid card, as now when we close the stream on port change we can just set voicecall record appropriate settings to the stream when changing to voicecall input route. Since voicecall recording usually requires mono stream, we use that for voicecall input, and if the source is set up with differing channel map we do internal resampling from mono to source channel specifications.