### PR TITLE
Fix pkgconf for debian based systems.

### DIFF
--- a/src/common/libdroid-util.pc.in
+++ b/src/common/libdroid-util.pc.in
@@ -7,5 +7,5 @@ libexecdir=@libexecdir@
 Name: libdroid-util
 Description: Common droid module building interface.
 Version: @PA_MODULE_VERSION@
-Libs: -L${libdir}/pulse-@PA_MAJORMINOR@/modules -ldroid-util
+Libs: -L${prefix}/lib/pulse-@PA_MAJORMINOR@/modules -ldroid-util
 Cflags: -D_REENTRANT -I${includedir}/pulsecore/modules


### PR DESCRIPTION
Since debian based systems uses /usr/lib/{arch} as libdir and /usr/lib/pulse-* for modules this causes -L to search for -ldroid-utils in /usr/lib/{arch}. This fixes this. 