### PR TITLE
Make sure QCOM_HARDWARE is defined when needed.

### DIFF
--- a/src/common/droid-util-audio.h
+++ b/src/common/droid-util-audio.h
@@ -22,6 +22,7 @@
 #ifndef _DROID_UTIL_AUDIO_H_
 #define _DROID_UTIL_AUDIO_H_
 
+#include <android-config.h>
 #ifdef QCOM_BSP
 #define QCOM_HARDWARE
 #endif

--- a/src/common/include/droid/version.h
+++ b/src/common/include/droid/version.h
@@ -24,6 +24,10 @@
 
 
 #include <android-config.h>
+#ifdef QCOM_BSP
+#define QCOM_HARDWARE
+#endif
+
 #include <hardware/audio.h>
 
 #if !defined(ANDROID_VERSION_MAJOR) || !defined(ANDROID_VERSION_MINOR) || !defined(ANDROID_VERSION_PATCH)


### PR DESCRIPTION
Droid headers define different things sometimes if QCOM_HARDWARE is
defined. Make sure that before including hardware/audio.h either
version.h or android-config.h is included so that the define is
correctly set if needed.