### PR TITLE
Fix voicecall recording on Jolla1.

### DIFF
--- a/src/common/include/droid/version.h
+++ b/src/common/include/droid/version.h
@@ -24,7 +24,7 @@
 
 
 #include <android-config.h>
-#ifdef QCOM_BSP
+#if defined(QCOM_BSP) || defined(DROID_DEVICE_SBJ)
 #define QCOM_HARDWARE
 #endif
 


### PR DESCRIPTION
When refactoring code for XML configuration parsing QCOM_HARDWARE define
was lost on Jolla1. This broke at least voicecall recording.