### PR TITLE
droid-sink droid-source: Return from process_msg only on error.

### DIFF
--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -525,7 +525,9 @@ static int sink_process_msg(pa_msgobject *o, int code, void *data, int64_t offse
 
 #if PULSEAUDIO_VERSION < 12
         case PA_SINK_MESSAGE_SET_STATE: {
-            return sink_set_state_in_io_thread_cb(u->sink, PA_PTR_TO_UINT(data), 0);
+            int r;
+            if ((r = sink_set_state_in_io_thread_cb(u->sink, PA_PTR_TO_UINT(data), 0)) < 0)
+                return r;
         }
 #endif
     }

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -337,7 +337,9 @@ static int source_process_msg(pa_msgobject *o, int code, void *data, int64_t off
 
 #if PULSEAUDIO_VERSION < 12
         case PA_SOURCE_MESSAGE_SET_STATE: {
-            return source_set_state_in_io_thread_cb(u->source, PA_PTR_TO_UINT(data), 0);
+            int r;
+            if ((r = source_set_state_in_io_thread_cb(u->source, PA_PTR_TO_UINT(data), 0)) < 0)
+                return r;
         }
 #endif
     }


### PR DESCRIPTION
When updating the implementation to support PulseAudio 12.2 the handling
of sink/source process msg function with older PulseAudio versions
incorrectly returns always, when that should only be done in case of
error.