### PR TITLE
Fix compatibility with pulseaudio>=13.0

### DIFF
--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -54,6 +54,7 @@
 #include <pulsecore/time-smoother.h>
 #include <pulsecore/hashmap.h>
 #include <pulsecore/core-subscribe.h>
+#include <pulse/version.h>
 
 #include "droid-sink.h"
 #include <droid/droid-util.h>
@@ -371,7 +372,11 @@ static void thread_func(void *userdata) {
     pa_log_debug("Thread starting up.");
 
     if (u->core->realtime_scheduling)
+#if (PA_CHECK_VERSION(13,0,0))
+        pa_thread_make_realtime(u->core->realtime_priority);
+#else
         pa_make_realtime(u->core->realtime_priority);
+#endif
 
     pa_thread_mq_install(&u->thread_mq);
 

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -51,6 +51,7 @@
 #include <pulsecore/rtpoll.h>
 #include <pulsecore/time-smoother.h>
 #include <pulsecore/resampler.h>
+#include <pulse/version.h>
 
 #include "droid-source.h"
 #include <droid/droid-util.h>
@@ -208,7 +209,11 @@ static void thread_func(void *userdata) {
     pa_log_debug("Thread starting up.");
 
     if (u->core->realtime_scheduling)
+#if (PA_CHECK_VERSION(13,0,0))
+        pa_thread_make_realtime(u->core->realtime_priority);
+#else
         pa_make_realtime(u->core->realtime_priority);
+#endif
 
     pa_thread_mq_install(&u->thread_mq);
 
@@ -366,7 +371,11 @@ static int source_set_port_cb(pa_source *s, pa_device_port *p) {
 
     pa_log_debug("Source set port %u", data->device);
 
+#if (PA_CHECK_VERSION(13,0,0))
+    if (!PA_SOURCE_IS_OPENED(u->source->state))
+#else
     if (!PA_SOURCE_IS_OPENED(pa_source_get_state(u->source)))
+#endif
         do_routing(u, data->device);
     else {
         pa_asyncmsgq_post(u->source->asyncmsgq, PA_MSGOBJECT(u->source), SOURCE_MESSAGE_DO_ROUTING, PA_UINT_TO_PTR(data->device), 0, NULL, NULL);

--- a/src/droid/module-droid-keepalive.c
+++ b/src/droid/module-droid-keepalive.c
@@ -31,6 +31,7 @@
 #endif
 
 #include <pulse/xmalloc.h>
+#include <pulse/version.h>
 
 #include <pulsecore/core.h>
 #include <pulsecore/i18n.h>
@@ -86,7 +87,11 @@ static void stop(struct userdata *u) {
         return;
 
     while ((sink = pa_idxset_iterate(u->core->sinks, &state, NULL))) {
+#if (PA_CHECK_VERSION(13,0,0))
+        if (sink->state != PA_SINK_SUSPENDED)
+#else
         if (pa_sink_get_state(sink) != PA_SINK_SUSPENDED)
+#endif
             return;
     }
 
@@ -94,7 +99,11 @@ static void stop(struct userdata *u) {
     while ((source = pa_idxset_iterate(u->core->sources, &state, NULL))) {
         if (source->monitor_of)
             continue;
+#if (PA_CHECK_VERSION(13,0,0))
+        if (source->state != PA_SOURCE_SUSPENDED)
+#else
         if (pa_source_get_state(source) != PA_SOURCE_SUSPENDED)
+#endif
             return;
     }
 
@@ -107,7 +116,11 @@ static void update_sink(pa_sink *sink, struct userdata *u) {
     pa_assert(sink);
     pa_assert(u);
 
+#if (PA_CHECK_VERSION(13,0,0))
+    if (sink->state != PA_SINK_SUSPENDED)
+#else
     if (pa_sink_get_state(sink) != PA_SINK_SUSPENDED)
+#endif
         start(u);
     else
         stop(u);
@@ -119,7 +132,11 @@ static void update_source(pa_source *source, struct userdata *u) {
 
     /* Don't react on monitor state changes. */
     if (!source->monitor_of) {
+#if (PA_CHECK_VERSION(13,0,0))
+        if (source->state != PA_SOURCE_SUSPENDED)
+#else
         if (pa_source_get_state(source) != PA_SOURCE_SUSPENDED)
+#endif
             start(u);
         else
             stop(u);


### PR DESCRIPTION
There were some API changes:
 - https://gitlab.freedesktop.org/pulseaudio/pulseaudio/commit/878ef440797f0fe319dcb1e866c29cec39b8a36d
 - https://gitlab.freedesktop.org/pulseaudio/pulseaudio/commit/6665b466d28ca6f166c22846777f541f5bc9cef7

When compiled with pulseaudio >= 13.0, there will be errors at run time:
* Error relocating /usr/lib/pulse-13.0/modules/libdroid-sink.so: pa_make_realtime: symbol not found
* Error relocating /usr/lib/pulse-13.0/modules/libdroid-source.so: pa_make_realtime: symbol not found
* Error relocating /usr/lib/pulse-13.0/modules/libdroid-source.so: pa_source_get_state: symbol not found

Fixes are:
 - include <pulse/util.h>, replace pa_make_realtime -> pa_thread_make_realtime
 - replace pa_source_get_state(X) -> X->state
 - replace pa_sink_get_state(X) -> X->state