### PR TITLE
common: Add support for 24-bit audio in 32-bit data

### DIFF
--- a/src/common/droid-util-audio.h
+++ b/src/common/droid-util-audio.h
@@ -89,8 +89,9 @@ uint32_t conversion_table_input_channel[][2] = {
 uint32_t conversion_table_format[][2] = {
     { PA_SAMPLE_U8,             AUDIO_FORMAT_PCM_8_BIT              },
     { PA_SAMPLE_S16LE,          AUDIO_FORMAT_PCM_16_BIT             },
-    { PA_SAMPLE_S32LE,          AUDIO_FORMAT_PCM_32_BIT             },
-    { PA_SAMPLE_S24LE,          AUDIO_FORMAT_PCM_24_BIT_PACKED      }
+    { PA_SAMPLE_S24_32LE,       AUDIO_FORMAT_PCM_8_24_BIT           },
+    { PA_SAMPLE_S24LE,          AUDIO_FORMAT_PCM_24_BIT_PACKED      },
+    { PA_SAMPLE_S32LE,          AUDIO_FORMAT_PCM_32_BIT             }
 };
 
 uint32_t conversion_table_default_audio_source[][2] = {


### PR DESCRIPTION
The Android format AUDIO_FORMAT_PCM_8_24_BIT matches PA_SAMPLE_S24_32LE. Sort formats alphabetically.

[common] Add support for 24-bit audio in 32-bit data. JB#60691