### PR TITLE
card: notify audio HAL about headphone/headset connection state

### DIFF
--- a/src/common/conversion.c
+++ b/src/common/conversion.c
@@ -217,6 +217,10 @@ bool pa_droid_output_port_name(audio_devices_t value, const char **to_str) {
     return string_convert_num_to_str(string_conversion_table_output_device_fancy, (uint32_t) value, to_str);
 }
 
+bool pa_droid_output_port_name_to_device(const char *str, audio_devices_t *to_value) {
+    return string_convert_str_to_num(string_conversion_table_output_device_fancy, str, to_value);
+}
+
 bool pa_droid_input_port_name(audio_devices_t value, const char **to_str) {
     return string_convert_num_to_str(string_conversion_table_input_device_fancy, (uint32_t) value, to_str);
 }

--- a/src/common/include/droid/conversion.h
+++ b/src/common/include/droid/conversion.h
@@ -79,6 +79,7 @@ bool pa_input_device_default_audio_source(audio_devices_t input_device, audio_so
 
 /* Pretty port names */
 bool pa_droid_output_port_name(audio_devices_t value, const char **to_str);
+bool pa_droid_output_port_name_to_device(const char *str, audio_devices_t *to_value);
 bool pa_droid_input_port_name(audio_devices_t value, const char **to_str);
 
 int pa_conversion_parse_list(pa_conversion_string_t type, const char *separator,

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -23,6 +23,7 @@
 #include <config.h>
 #endif
 
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 
@@ -59,6 +60,7 @@
 //#include <droid/hardware/audio_policy.h>
 //#include <droid/system/audio_policy.h>
 
+#include <droid/conversion.h>
 #include <droid/droid-util.h>
 #include <droid/sllist.h>
 #include <droid/utils.h>
@@ -777,6 +779,53 @@ static int card_set_profile(pa_card *c, pa_card_profile *new_profile) {
     return 0;
 }
 
+static pa_hook_result_t port_sink_changed_hook_callback(void *hook_data, void *call_data, void *slot_data) {
+    pa_sink *sink = call_data;
+    pa_device_port *port = sink->active_port;
+    struct userdata *u = slot_data;
+
+    pa_log_info("port_sink_changed_hook_callback");
+    /* Not meant for us */
+    if (port->card != u->card) {
+        pa_log_info("port_sink_changed_hook_callback: Incorrect card %d %d", port->card, u->card);
+        return PA_HOOK_OK;
+    }
+
+    /* Track only outputs for now. */
+    if (port->direction != PA_DIRECTION_OUTPUT) {
+        pa_log_info("port_sink_changed_hook_callback: Direction not output");
+        return PA_HOOK_OK;
+    }
+
+    /* We don't track availability of this port. */
+    if (port->available == PA_AVAILABLE_UNKNOWN) {
+        pa_log_info("port_sink_changed_hook_callback: Availability unknown");
+        return PA_HOOK_OK;
+    }
+
+    const char * verb = port->available == PA_AVAILABLE_YES
+        ? AUDIO_PARAMETER_DEVICE_CONNECT
+        : AUDIO_PARAMETER_DEVICE_DISCONNECT;
+
+    uint32_t device;
+    if (!pa_droid_output_port_name_to_device(port->name, &device)) {
+            pa_log_warn("Can't notify Android of port '%s' as it's unknown.",
+                                     port->name);
+            return PA_HOOK_OK;
+    }
+
+    pa_log_info("Notifying Android of port '%s' (%" PRIu32 ") becoming %s.",
+                            port->name, device,
+                            port->available == PA_AVAILABLE_YES ? "available" : "not available");
+
+    char * setparam = pa_sprintf_malloc("%s=%" PRIu32 "", verb, device);
+    pa_droid_set_parameters(u->hw_module, setparam);
+
+    pa_xfree(setparam);
+
+    return PA_HOOK_OK;
+}
+
 
 int pa__init(pa_module *m) {
     struct userdata *u = NULL;
@@ -894,6 +943,13 @@ int pa__init(pa_module *m) {
 
     pa_card_choose_initial_profile(u->card);
     init_profile(u);
+
+    pa_log_info("Installing hook for port_sink_changed");
+    pa_module_hook_connect(u->module,
+                           &u->module->core->hooks[PA_CORE_HOOK_SINK_PORT_CHANGED],
+                           PA_HOOK_NORMAL,
+                           port_sink_changed_hook_callback, u);
+
     pa_card_put(u->card);
 
     return 0;


### PR DESCRIPTION
Audio HAL implementation on MediaTek Android 12+ devices tracks headphone/headset connection state internally and will not write buffer to underlying audio device if it considers the port disconnected.

Use AUDIO_PARAMETER_DEVICE_CONNECT/AUDIO_PARAMETER_DEVICE_DISCONNECT to notify it about current headphone/headset connection state.

This implementation builds upon Nikita (NotKit, TheKit)'s implementation and moves the call to `pa_droid_set_parameters()` to be inside `module- droid-card.c` itself. This removes duplicated code and separates the notification code from detection code. It also makes device id lookup more dynamic reusing existing table.

Reworked from Halium patch 2014, instead of using
PA_CORE_HOOK_PORT_AVAILABLE_CHANGED, now using
PA_CORE_HOOK_SINK_PORT_CHANGED and does not require the other patches in 2002 and 2004 to monitor using evdev

Author: ratchanan@ubports.com