### PR TITLE
Fix several issues with Android 16 base

### DIFF
--- a/src/common/config-parser-xml.c
+++ b/src/common/config-parser-xml.c
@@ -866,6 +866,17 @@ static bool parse_device_port(struct parser_data *data, const char *element_name
     /* address is not mandatory element attribute */
     get_element_attr(data, attributes, false, ATTRIBUTE_address, &d->address);
 
+    /* microphone input ports have default address values */
+#if ANDROID_VERSION_MAJOR >= 9
+    if (!d->address) {
+        if (d->type == AUDIO_DEVICE_IN_BUILTIN_MIC) {
+            d->address = pa_sprintf_malloc(AUDIO_BOTTOM_MICROPHONE_ADDRESS);
+        } else if (d->type == AUDIO_DEVICE_IN_BACK_MIC) {
+            d->address = pa_sprintf_malloc(AUDIO_BACK_MICROPHONE_ADDRESS);
+        }
+    }
+#endif
+
     parsed = true;
 done:
     pa_xfree(type);

--- a/src/common/droid-util-audio.h
+++ b/src/common/droid-util-audio.h
@@ -333,6 +333,10 @@ struct string_conversion string_conversion_table_output_flag[] = {
     STRING_ENTRY( AUDIO_OUTPUT_FLAG_MMAP_NOIRQ                      ),
     STRING_ENTRY( AUDIO_OUTPUT_FLAG_VOIP_RX                         ),
     STRING_ENTRY( AUDIO_OUTPUT_FLAG_INCALL_MUSIC                    ),
+    STRING_ENTRY( AUDIO_OUTPUT_FLAG_GAPLESS_OFFLOAD                 ),
+    STRING_ENTRY( AUDIO_OUTPUT_FLAG_SPATIALIZER                     ),
+    STRING_ENTRY( AUDIO_OUTPUT_FLAG_ULTRASOUND                      ),
+    STRING_ENTRY( AUDIO_OUTPUT_FLAG_BIT_PERFECT                     ),
 
     /* Audio output flags which may or may not be defined for all devices. */
     STRING_ENTRY_IF_AUDIO_OUTPUT_FLAG_COMPRESS_PASSTHROUGH

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -1415,6 +1415,8 @@ static bool stream_config_fill(pa_droid_hw_module *hw,
     config->sample_rate = compatible_sample_spec.rate;
     config->channel_mask = hal_channel_mask;
     config->format = hal_audio_format;
+    config->offload_info.version = AUDIO_OFFLOAD_INFO_VERSION_CURRENT;
+    config->offload_info.size = sizeof(audio_offload_info_t);
 
     *sample_spec = compatible_sample_spec;
     *channel_map = compatible_channel_map;


### PR DESCRIPTION
Add some missing audio output flags. Initialize offload into in stream config. Set default address values for microphones.