### PR TITLE
Wired accessory handling.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ hybris_common_dep = cc.find_library('hybris-common', required : true)
 ltdl_dep = cc.find_library('ltdl', required : true)
 pulsecore_dep = dependency('pulsecore', version : '>= 14.2', required : true)
 libudev_dep = dependency('libudev', required : true)
+alsa_dep = dependency('alsa', required : true)
 
 pa_version_str = pulsecore_dep.version()
 # For tarballs, the first split will do nothing, but for builds in git, we

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ hybris_dep = dependency('libhardware', version : '>= 0.1.0', required : true)
 hybris_common_dep = cc.find_library('hybris-common', required : true)
 ltdl_dep = cc.find_library('ltdl', required : true)
 pulsecore_dep = dependency('pulsecore', version : '>= 14.2', required : true)
+libudev_dep = dependency('libudev', required : true)
 
 pa_version_str = pulsecore_dep.version()
 # For tarballs, the first split will do nothing, but for builds in git, we

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ hybris_common_dep = cc.find_library('hybris-common', required : true)
 ltdl_dep = cc.find_library('ltdl', required : true)
 pulsecore_dep = dependency('pulsecore', version : '>= 14.2', required : true)
 libudev_dep = dependency('libudev', required : true)
+libevdev_dep = dependency('libevdev', required : true)
 
 pa_version_str = pulsecore_dep.version()
 # For tarballs, the first split will do nothing, but for builds in git, we

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ pa_c_args += ['-DDROID_DEVICE_@0@=1'.format(droiddevice.underscorify().to_upper(
 pa_c_args += ['-DDROID_DEVICE_STRING="@0@"'.format(droiddevice)]
 
 # dependencies
-droid_headers_dep = dependency('android-headers', required : true)
+droid_headers_dep = dependency(get_option('android-headers'), required : true)
 expat_dep = dependency('expat', version : '>= 2.1', required : true)
 hybris_dep = dependency('libhardware', version : '>= 0.1.0', required : true)
 hybris_common_dep = cc.find_library('hybris-common', required : true)
@@ -42,6 +42,12 @@ endif
 
 privlibdir = join_paths(libdir, 'pulseaudio')
 rpath_dirs = join_paths(privlibdir) + ':' + join_paths(modlibexecdir)
+
+if get_option('module-suffix') == ''
+  droid_module_suffix = ''
+else
+  droid_module_suffix = '-' + get_option('module-suffix')
+endif
 
 cdata = configuration_data()
 cdata.set_quoted('PACKAGE', meson.project_name())

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,6 @@ hybris_common_dep = cc.find_library('hybris-common', required : true)
 ltdl_dep = cc.find_library('ltdl', required : true)
 pulsecore_dep = dependency('pulsecore', version : '>= 14.2', required : true)
 libudev_dep = dependency('libudev', required : true)
-libevdev_dep = dependency('libevdev', required : true)
 
 pa_version_str = pulsecore_dep.version()
 # For tarballs, the first split will do nothing, but for builds in git, we

--- a/meson.build
+++ b/meson.build
@@ -45,9 +45,13 @@ rpath_dirs = join_paths(privlibdir) + ':' + join_paths(modlibexecdir)
 
 if get_option('module-suffix') == ''
   droid_module_suffix = ''
+  pc_header_dir = 'pulsecore/modules'
 else
   droid_module_suffix = '-' + get_option('module-suffix')
+  pc_header_dir = 'pulsecore/modules/droid' + droid_module_suffix
 endif
+
+header_install_path = pc_header_dir + '/droid'
 
 cdata = configuration_data()
 cdata.set_quoted('PACKAGE', meson.project_name())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,3 +13,12 @@ option('droid-device',
 option('modlibexecdir',
        type : 'string',
        description : 'Specify location where modules will be installed')
+
+option('android-headers',
+       type : 'string',
+       value : 'android-headers',
+       description : 'Specify custom android headers package')
+option('module-suffix',
+       type : 'string',
+       value : '',
+       description : 'Specify suffixes to all modules and libraries. "-" will be included automatically')

--- a/rpm/pulseaudio-modules-droid.spec
+++ b/rpm/pulseaudio-modules-droid.spec
@@ -20,6 +20,8 @@ BuildRequires:  pkgconfig(pulsecore) >= %{pulsemajorminor}
 BuildRequires:  pkgconfig(android-headers)
 BuildRequires:  pkgconfig(libhardware)
 BuildRequires:  pkgconfig(expat)
+BuildRequires:  pkgconfig(alsa)
+BuildRequires:  pkgconfig(libudev)
 
 %description
 PulseAudio Droid HAL modules.

--- a/src/common/config-parser-xml.c
+++ b/src/common/config-parser-xml.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2018-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/config-parser-xml.h
+++ b/src/common/config-parser-xml.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/conversion.c
+++ b/src/common/conversion.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/conversion.c
+++ b/src/common/conversion.c
@@ -217,6 +217,10 @@ bool pa_droid_output_port_name(audio_devices_t value, const char **to_str) {
     return string_convert_num_to_str(string_conversion_table_output_device_fancy, (uint32_t) value, to_str);
 }
 
+bool pa_droid_output_port_name_to_device(const char *str, audio_devices_t *to_value) {
+    return string_convert_str_to_num(string_conversion_table_output_device_fancy, str, to_value);
+}
+
 bool pa_droid_input_port_name(audio_devices_t value, const char **to_str) {
     return string_convert_num_to_str(string_conversion_table_input_device_fancy, (uint32_t) value, to_str);
 }

--- a/src/common/droid-config.c
+++ b/src/common/droid-config.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/droid-util-audio.h
+++ b/src/common/droid-util-audio.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2017-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -581,6 +581,35 @@ pa_droid_mapping *pa_droid_idxset_get_primary(pa_idxset *i) {
     return NULL;
 }
 
+/* Only physically connected ports are available initially. */
+static pa_available_t connected_port(dm_config_port *port) {
+    /* Parking pa_droid_port port doesn't have dm_config_port,
+     * but the port is always available. */
+    if (!port)
+        return PA_AVAILABLE_YES;
+
+    if (port->type & AUDIO_DEVICE_BIT_IN) {
+        audio_devices_t input_port = port->type & ~AUDIO_DEVICE_BIT_IN;
+        if (input_port & (AUDIO_DEVICE_IN_AMBIENT           |
+                          AUDIO_DEVICE_IN_BUILTIN_MIC       |
+                          AUDIO_DEVICE_IN_TELEPHONY_RX      |
+                          AUDIO_DEVICE_IN_BACK_MIC          |
+                          AUDIO_DEVICE_IN_REMOTE_SUBMIX))
+
+            return PA_AVAILABLE_YES;
+    } else {
+        if (port->type & (AUDIO_DEVICE_OUT_SPEAKER          |
+                          AUDIO_DEVICE_OUT_REMOTE_SUBMIX    |
+                          AUDIO_DEVICE_OUT_TELEPHONY_TX     |
+                          AUDIO_DEVICE_OUT_SPEAKER_SAFE     |
+                          AUDIO_DEVICE_OUT_PROXY))
+
+            return PA_AVAILABLE_YES;
+    }
+
+    return PA_AVAILABLE_NO;
+}
+
 static int add_ports(pa_core *core, pa_card_profile *cp, pa_hashmap *ports, pa_droid_mapping *am, pa_hashmap *extra) {
     pa_droid_port *p;
     pa_device_port_new_data dp_data;
@@ -602,7 +631,7 @@ static int add_ports(pa_core *core, pa_card_profile *cp, pa_hashmap *ports, pa_d
             pa_device_port_new_data_set_name(&dp_data, p->name);
             pa_device_port_new_data_set_description(&dp_data, p->description);
             pa_device_port_new_data_set_direction(&dp_data, p->mapping->direction);
-            pa_device_port_new_data_set_available(&dp_data, PA_AVAILABLE_YES);
+            pa_device_port_new_data_set_available(&dp_data, connected_port(p->device_port));
 
             dp = pa_droid_device_port_new(core, &dp_data, p->device_port);
             dp->priority = p->priority;

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -2328,8 +2328,10 @@ static int input_stream_set_route(pa_droid_stream *stream, const dm_config_port 
     input = stream->input;
 
      /* Input stream closed, no need for routing changes */
-    if (!input->stream)
+    if (!input->stream) {
+        pa_log_debug("No routing changes for closed input stream.");
         goto done;
+    }
 
     if (!pa_droid_option(stream->module, DM_OPTION_USE_LEGACY_STREAM_SET_PARAMETERS)) {
         audio_patch_release(stream);

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -2269,12 +2269,9 @@ done:
 
 int output_stream_set_parameter(pa_droid_stream *s, const dm_config_port *device_port){
     pa_droid_output_stream *output;
-    pa_droid_stream *slave;
-    uint32_t idx;
     char *parameters = NULL;
     int ret = 0;
     audio_devices_t device;
-    pa_droid_hw_module *hw_module;
     int set_bt_sco = -1;
 
     pa_assert(s);
@@ -2283,7 +2280,6 @@ int output_stream_set_parameter(pa_droid_stream *s, const dm_config_port *device
     pa_assert(s->module->output_mutex);
 
     output = s->output;
-    hw_module = s->module;
     device = device_port->type;
 
     pa_mutex_lock(s->module->output_mutex);

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -2747,5 +2747,25 @@ pa_device_port *pa_droid_device_port_new(pa_core *c, pa_device_port_new_data *dp
     dp->profiles = pa_hashmap_new(pa_idxset_string_hash_func, pa_idxset_string_compare_func);
     data = PA_DEVICE_PORT_DATA(dp);
     data->device_port = device_port;
+    pa_droid_device_port_set_usb_disconnected(dp);
+
     return dp;
+}
+
+void pa_droid_device_port_set_usb_connected(pa_device_port *port, int card, int device) {
+    pa_assert(port);
+
+    pa_droid_port_data *data = PA_DEVICE_PORT_DATA(port);
+
+    data->usb.card = card;
+    data->usb.device = device;
+}
+
+void pa_droid_device_port_set_usb_disconnected(pa_device_port *port) {
+    pa_assert(port);
+
+    pa_droid_port_data *data = PA_DEVICE_PORT_DATA(port);
+
+    data->usb.card = -1;
+    data->usb.device = -1;
 }

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -585,7 +585,6 @@ static int add_ports(pa_core *core, pa_card_profile *cp, pa_hashmap *ports, pa_d
     pa_droid_port *p;
     pa_device_port_new_data dp_data;
     pa_device_port *dp;
-    pa_droid_port_data *data;
     uint32_t idx;
     int count = 0;
 
@@ -605,16 +604,12 @@ static int add_ports(pa_core *core, pa_card_profile *cp, pa_hashmap *ports, pa_d
             pa_device_port_new_data_set_direction(&dp_data, p->mapping->direction);
             pa_device_port_new_data_set_available(&dp_data, PA_AVAILABLE_YES);
 
-            dp = pa_device_port_new(core, &dp_data, sizeof(pa_droid_port_data));
+            dp = pa_droid_device_port_new(core, &dp_data, p->device_port);
             dp->priority = p->priority;
 
             pa_device_port_new_data_done(&dp_data);
 
             pa_hashmap_put(ports, dp->name, dp);
-            dp->profiles = pa_hashmap_new(pa_idxset_string_hash_func, pa_idxset_string_compare_func);
-
-            data = PA_DEVICE_PORT_DATA(dp);
-            data->device_port = p->device_port;
         } else
             pa_log_debug("  Port %s from cache", p->name);
 
@@ -2710,4 +2705,18 @@ pa_modargs *pa_droid_modargs_new(const char *args, const char* const keys[]) {
     pa_xfree(full_keys);
 
     return ma;
+}
+
+pa_device_port *pa_droid_device_port_new(pa_core *c, pa_device_port_new_data *dp_data, dm_config_port *device_port) {
+    pa_device_port *dp;
+    pa_droid_port_data *data;
+
+    pa_assert(c);
+    pa_assert(dp_data);
+
+    dp = pa_device_port_new(c, dp_data, sizeof(pa_droid_port_data));
+    dp->profiles = pa_hashmap_new(pa_idxset_string_hash_func, pa_idxset_string_compare_func);
+    data = PA_DEVICE_PORT_DATA(dp);
+    data->device_port = device_port;
+    return dp;
 }

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2026 Jolla Mobile Ltd
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -2173,7 +2173,7 @@ static int droid_output_stream_audio_patch_update(pa_droid_stream *primary_strea
     pa_assert(primary_stream);
     pa_assert(primary_stream->output);
     pa_assert(primary_stream->mix_port);
-    pa_assert(primary_stream->mix_port->type == DM_CONFIG_TYPE_MIX);
+    pa_assert(primary_stream->mix_port->port_type == DM_CONFIG_TYPE_MIX_PORT);
     pa_assert(primary_stream->mix_port->flags & AUDIO_OUTPUT_FLAG_PRIMARY);
     pa_assert(device_port);
     pa_assert(device_port->role == DM_CONFIG_ROLE_SINK);

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -2140,7 +2140,7 @@ static int audio_patch_update_output(pa_droid_stream *stream, const dm_config_po
     sink.format = AUDIO_FORMAT_PCM_16_BIT;
     sink.ext.device.address[0] = '\0';
     if (strlen(device_port->address))
-        strncpy(sink.ext.device.address, device_port->address, AUDIO_DEVICE_MAX_ADDRESS_LEN);
+        strncpy(sink.ext.device.address, device_port->address, AUDIO_DEVICE_MAX_ADDRESS_LEN - 1);
     sink.ext.device.type = device_port->type;
 
     ret = stream->module->device->create_audio_patch(stream->module->device, 1, &source, 1, &sink, &stream->audio_patch);
@@ -2176,7 +2176,7 @@ static int audio_patch_update_input(pa_droid_stream *stream, const dm_config_por
     source.format = AUDIO_FORMAT_PCM_16_BIT;
     source.ext.device.address[0] = '\0';
     if (strlen(device_port->address))
-        strncpy(source.ext.device.address, device_port->address, AUDIO_DEVICE_MAX_ADDRESS_LEN);
+        strncpy(source.ext.device.address, device_port->address, AUDIO_DEVICE_MAX_ADDRESS_LEN - 1);
     source.ext.device.type = device_port->type;
 
     ret = stream->module->device->create_audio_patch(stream->module->device, 1, &source, 1, &sink, &stream->audio_patch);

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Jolla Ltd.
+ * Copyright (C) 2013-2026 Jolla Mobile Ltd
  *
  * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
  *
@@ -92,6 +92,7 @@ struct droid_option valid_options[] = {
     { "output_voip_rx",                    DM_OPTION_OUTPUT_VOIP_RX                    },
     { "record_voice_16k",                  DM_OPTION_RECORD_VOICE_16K                  },
     { "use_legacy_stream_set_parameters",  DM_OPTION_USE_LEGACY_STREAM_SET_PARAMETERS  },
+    { "usb_devices",                       DM_OPTION_USB_DEVICES                       },
 
 };
 

--- a/src/common/droid-util.c
+++ b/src/common/droid-util.c
@@ -1446,6 +1446,9 @@ static dm_config_port *stream_select_mix_port(pa_droid_stream *stream) {
             if (port->role != DM_CONFIG_ROLE_SINK)
                 continue;
 
+            if (port->port_type != DM_CONFIG_TYPE_MIX_PORT)
+                continue;
+
             if (port->flags & AUDIO_INPUT_FLAG_VOIP_TX) {
                 selected_port = port;
                 goto done;
@@ -1463,7 +1466,14 @@ static dm_config_port *stream_select_mix_port(pa_droid_stream *stream) {
                 if (port->role != DM_CONFIG_ROLE_SOURCE)
                     continue;
 
+                if (port->port_type != DM_CONFIG_TYPE_DEVICE_PORT)
+                    continue;
+
                 if (port->type == AUDIO_DEVICE_IN_TELEPHONY_RX) {
+                    if (route->sink->port_type != DM_CONFIG_TYPE_MIX_PORT) {
+                        pa_log_debug("Input device in odd place.");
+                        continue;
+                    }
                     selected_port = route->sink;
                     goto done;
                 }

--- a/src/common/include/droid/conversion.h
+++ b/src/common/include/droid/conversion.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2018-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/include/droid/conversion.h
+++ b/src/common/include/droid/conversion.h
@@ -79,6 +79,7 @@ bool pa_input_device_default_audio_source(audio_devices_t input_device, audio_so
 
 /* Pretty port names */
 bool pa_droid_output_port_name(audio_devices_t value, const char **to_str);
+bool pa_droid_output_port_name_to_device(const char *str, audio_devices_t *to_value);
 bool pa_droid_input_port_name(audio_devices_t value, const char **to_str);
 
 int pa_conversion_parse_list(pa_conversion_string_t type, const char *separator,

--- a/src/common/include/droid/droid-config.h
+++ b/src/common/include/droid/droid-config.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2018-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/include/droid/droid-util.h
+++ b/src/common/include/droid/droid-util.h
@@ -171,6 +171,10 @@ typedef struct pa_droid_mapping pa_droid_mapping;
 
 typedef struct pa_droid_port_data {
     dm_config_port *device_port;
+    struct {
+        int card;
+        int device;
+    } usb;
 } pa_droid_port_data;
 
 typedef struct pa_droid_port {
@@ -354,6 +358,10 @@ bool pa_source_is_droid_source(pa_source *source);
 pa_modargs *pa_droid_modargs_new(const char *args, const char* const keys[]);
 
 pa_device_port *pa_droid_device_port_new(pa_core *c, pa_device_port_new_data *data, dm_config_port *device_port);
+
+void pa_droid_device_port_set_usb_connected(pa_device_port *port, int card, int device);
+void pa_droid_device_port_set_usb_disconnected(pa_device_port *port);
+
 /* Misc */
 size_t pa_droid_buffer_size_round_up(size_t buffer_size, size_t block_size);
 

--- a/src/common/include/droid/droid-util.h
+++ b/src/common/include/droid/droid-util.h
@@ -2,7 +2,7 @@
 #define foodroidutilfoo
 
 /*
- * Copyright (C) 2013-2022 Jolla Ltd.
+ * Copyright (C) 2013-2026 Jolla Mobile Ltd
  *
  * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
  *
@@ -75,6 +75,7 @@ enum pa_droid_option_type {
     DM_OPTION_OUTPUT_VOIP_RX,
     DM_OPTION_RECORD_VOICE_16K,
     DM_OPTION_USE_LEGACY_STREAM_SET_PARAMETERS,
+    DM_OPTION_USB_DEVICES,
     DM_OPTION_COUNT
 };
 

--- a/src/common/include/droid/droid-util.h
+++ b/src/common/include/droid/droid-util.h
@@ -353,6 +353,7 @@ bool pa_source_is_droid_source(pa_source *source);
 
 pa_modargs *pa_droid_modargs_new(const char *args, const char* const keys[]);
 
+pa_device_port *pa_droid_device_port_new(pa_core *c, pa_device_port_new_data *data, dm_config_port *device_port);
 /* Misc */
 size_t pa_droid_buffer_size_round_up(size_t buffer_size, size_t block_size);
 

--- a/src/common/include/droid/droid-util.h
+++ b/src/common/include/droid/droid-util.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2013-2026 Jolla Mobile Ltd
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/include/droid/sllist.h
+++ b/src/common/include/droid/sllist.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2018-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/include/droid/utils.h
+++ b/src/common/include/droid/utils.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/include/droid/version.h
+++ b/src/common/include/droid/version.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2018-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/libdroid-util.pc.in
+++ b/src/common/libdroid-util.pc.in
@@ -4,8 +4,8 @@ libdir=@libdir@
 includedir=${prefix}/include
 libexecdir=@libexecdir@
 
-Name: libdroid-util
+Name: libdroid-util@DROID_MODULE_SUFFIX@
 Description: Common droid module building interface.
 Version: @PA_MODULE_VERSION@
-Libs: -L${libdir}/pulse-@PA_MAJORMINOR@/modules -ldroid-util
+Libs: -L${libdir}/pulse-@PA_MAJORMINOR@/modules -ldroid-util@DROID_MODULE_SUFFIX@
 Cflags: -D_REENTRANT -I${includedir}/pulsecore/modules

--- a/src/common/libdroid-util.pc.in
+++ b/src/common/libdroid-util.pc.in
@@ -8,4 +8,4 @@ Name: libdroid-util@DROID_MODULE_SUFFIX@
 Description: Common droid module building interface.
 Version: @PA_MODULE_VERSION@
 Libs: -L${libdir}/pulse-@PA_MAJORMINOR@/modules -ldroid-util@DROID_MODULE_SUFFIX@
-Cflags: -D_REENTRANT -I${includedir}/pulsecore/modules
+Cflags: -D_REENTRANT -I${includedir}/@PC_HEADER_DIR@

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -27,9 +27,10 @@ libdroid_util_deps = [
   pulsecore_dep,
 ]
 
-install_headers(libdroid_util_headers, subdir : 'pulsecore/modules/droid')
+install_headers(libdroid_util_headers,
+                subdir : 'pulsecore/modules/droid' + droid_module_suffix)
 
-libdroid_util = library('droid-util',
+libdroid_util = library('droid-util' + droid_module_suffix,
   libdroid_util_sources,
   c_args : [pa_c_args, '-DPULSEAUDIO_VERSION=@0@'.format(pa_version_major)],
   dependencies : libdroid_util_deps,
@@ -55,10 +56,11 @@ pc_cdata.set('libdir', libdir)
 pc_cdata.set('libexecdir', get_option('libexecdir'))
 pc_cdata.set('PA_MAJORMINOR', pa_version_major_minor)
 pc_cdata.set('PA_MODULE_VERSION', pa_version_module)
+pc_cdata.set('DROID_MODULE_SUFFIX', droid_module_suffix)
 
 configure_file(
   input : 'libdroid-util.pc.in',
-  output : 'libdroid-util.pc',
+  output : 'libdroid-util' + droid_module_suffix + '.pc',
   configuration : pc_cdata,
   install_dir : join_paths(libdir, 'pkgconfig')
 )

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -27,8 +27,7 @@ libdroid_util_deps = [
   pulsecore_dep,
 ]
 
-install_headers(libdroid_util_headers,
-                subdir : 'pulsecore/modules/droid' + droid_module_suffix)
+install_headers(libdroid_util_headers, subdir : header_install_path)
 
 libdroid_util = library('droid-util' + droid_module_suffix,
   libdroid_util_sources,
@@ -57,6 +56,7 @@ pc_cdata.set('libexecdir', get_option('libexecdir'))
 pc_cdata.set('PA_MAJORMINOR', pa_version_major_minor)
 pc_cdata.set('PA_MODULE_VERSION', pa_version_module)
 pc_cdata.set('DROID_MODULE_SUFFIX', droid_module_suffix)
+pc_cdata.set('PC_HEADER_DIR', pc_header_dir)
 
 configure_file(
   input : 'libdroid-util.pc.in',

--- a/src/common/sllist.c
+++ b/src/common/sllist.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/droid/droid-extcon.c
+++ b/src/droid/droid-extcon.c
@@ -1,0 +1,264 @@
+/***
+  This file is part of PulseAudio.
+
+  Copyright (C) 2013 Canonical Ltd.
+  Contact: David Henningsson
+           Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
+
+  Copyright (C) 2026 Jolla Mobile Ltd
+
+  PulseAudio is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published
+  by the Free Software Foundation; either version 2.1 of the License,
+  or (at your option) any later version.
+
+  PulseAudio is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with PulseAudio; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <pulsecore/core-util.h>
+#include <pulsecore/device-port.h>
+#include <pulsecore/i18n.h>
+#include <libudev.h>
+
+#include "droid-extcon.h"
+
+/* For android */
+#define EXTCON_NAME "switch"
+
+static pa_available_t hponly_avail(int state)
+{
+    return (state & 2) ? PA_AVAILABLE_YES : PA_AVAILABLE_NO;
+}
+
+static pa_available_t hsmic_avail(int state)
+{
+    return (state & 1) ? PA_AVAILABLE_YES : PA_AVAILABLE_NO;
+}
+
+struct droid_switch {
+    char *name;
+    uint32_t current_value;
+};
+
+static void droid_switch_free(struct droid_switch *as) {
+    if (!as)
+        return;
+    pa_xfree(as->name);
+    pa_xfree(as);
+}
+
+static struct droid_switch *droid_switch_new(const char *name) {
+
+    struct droid_switch *as = NULL;
+    char *filename = pa_sprintf_malloc("/sys/class/%s/%s/state", EXTCON_NAME, name);
+    char *state = pa_read_line_from_file(filename);
+
+    if (state == NULL) {
+        pa_log_debug("Cannot open '%s'. Skipping.", filename);
+        pa_xfree(filename);
+        return NULL;
+    }
+    pa_xfree(filename);
+
+    as = pa_xnew0(struct droid_switch, 1);
+    as->name = pa_xstrdup(name);
+
+    if (pa_atou(state, &as->current_value) < 0) {
+        pa_log_warn("Switch '%s' has invalid value '%s'", name, state);
+        pa_xfree(state);
+        droid_switch_free(as);
+        return NULL;
+    }
+    pa_log_debug("Switch '%s' opened with value '%s'", name, state);
+    pa_xfree(state);
+
+    return as;
+}
+
+struct udev_data {
+    struct udev *udev;
+    struct udev_monitor *monitor;
+    pa_io_event *event;
+};
+
+struct pa_droid_extcon {
+    pa_card *card;
+    struct droid_switch *h2w;
+    struct udev_data udev;
+};
+
+static struct droid_switch *find_matching_switch(pa_droid_extcon *u,
+                                                   const char *devpath) {
+
+    if (pa_streq(devpath, "/devices/virtual/" EXTCON_NAME "/h2w"))
+        return u->h2w;  /* To be extended if we ever support more switches */
+    return NULL;
+}
+
+static void notify_ports(pa_droid_extcon *u, struct droid_switch *as) {
+
+    pa_device_port *p;
+    void *state;
+
+    pa_assert(as == u->h2w); /* To be extended if we ever support more switches */
+
+    pa_log_debug("Value of switch %s is now %d.", as->name, as->current_value);
+
+    PA_HASHMAP_FOREACH(p, u->card->ports, state) {
+        if (p->direction == PA_DIRECTION_OUTPUT) {
+            if (!strcmp(p->name, "output-wired_headset"))
+                pa_device_port_set_available(p, hsmic_avail(as->current_value));
+            if (!strcmp(p->name, "output-wired_headphone"))
+                pa_device_port_set_available(p, hponly_avail(as->current_value));
+        }
+        if (p->direction == PA_DIRECTION_INPUT) {
+            if (!strcmp(p->name, "input-wired_headset"))
+                pa_device_port_set_available(p, hsmic_avail(as->current_value));
+        }
+    }
+}
+
+static void udev_cb(pa_mainloop_api *a, pa_io_event *e, int fd,
+                    pa_io_event_flags_t events, void *userdata) {
+
+    pa_droid_extcon *u = userdata;
+    struct udev_device *d = udev_monitor_receive_device(u->udev.monitor);
+    struct udev_list_entry *entry;
+    struct droid_switch *as;
+    const char *devpath, *state;
+
+    if (!d) {
+        pa_log("udev_monitor_receive_device failed.");
+        pa_assert(a);
+        a->io_free(u->udev.event);
+        u->udev.event = NULL;
+        return;
+    }
+
+    devpath = udev_device_get_devpath(d);
+    if (!devpath) {
+        pa_log("udev_device_get_devpath failed.");
+        goto out;
+    }
+    pa_log_debug("Got uevent with devpath=%s", devpath);
+
+    as = find_matching_switch(u, devpath);
+    if (!as)
+        goto out;
+
+    entry = udev_list_entry_get_by_name(
+            udev_device_get_properties_list_entry(d), "SWITCH_STATE");
+    if (!entry) {
+        pa_log("udev_list_entry_get_by_name failed to find 'SWITCH_STATE' entry.");
+        goto out;
+    }
+
+    state = udev_list_entry_get_value(entry);
+    if (!state) {
+        pa_log("udev_list_entry_get_by_name failed.");
+        goto out;
+    }
+
+    if (pa_atou(state, &as->current_value) < 0) {
+        pa_log_warn("Switch '%s' has invalid value '%s'", as->name, state);
+        goto out;
+    }
+
+    notify_ports(u, as);
+
+out:
+    udev_device_unref(d);
+}
+
+static bool init_udev(pa_droid_extcon *u, pa_core *core) {
+
+    int fd;
+
+    u->udev.udev = udev_new();
+    if (!u->udev.udev) {
+        pa_log("udev_new failed.");
+        return false;
+    }
+
+    u->udev.monitor = udev_monitor_new_from_netlink(u->udev.udev, "udev");
+    if (!u->udev.monitor) {
+        pa_log("udev_monitor_new_from_netlink failed.");
+        return false;
+    }
+
+    if (udev_monitor_filter_add_match_subsystem_devtype(u->udev.monitor, EXTCON_NAME, NULL) < 0) {
+        pa_log("udev_monitor_filter_add_match_subsystem_devtype failed.");
+        return false;
+    }
+
+    if (udev_monitor_enable_receiving(u->udev.monitor) < 0) {
+        pa_log("udev_monitor_enable_receiving failed.");
+        return false;
+    }
+
+    fd = udev_monitor_get_fd(u->udev.monitor);
+    if (fd < 0) {
+        pa_log("udev_monitor_get_fd failed");
+        return false;
+    }
+
+    pa_assert_se(u->udev.event = core->mainloop->io_new(core->mainloop, fd,
+                 PA_IO_EVENT_INPUT, udev_cb, u));
+
+    return true;
+}
+
+pa_droid_extcon *pa_droid_extcon_new(pa_core *core, pa_card *card) {
+
+    pa_droid_extcon *u = pa_xnew0(pa_droid_extcon, 1);
+
+    pa_assert(core);
+    pa_assert(card);
+
+    u->card = card;
+    u->h2w = droid_switch_new("h2w");
+    if (!u->h2w)
+        goto fail;
+
+    if (!init_udev(u, core))
+        goto fail;
+
+    notify_ports(u, u->h2w);
+
+    return u;
+
+fail:
+    pa_droid_extcon_free(u);
+    return NULL;
+}
+
+void pa_droid_extcon_free(pa_droid_extcon *u) {
+
+    pa_assert(u);
+
+    if (u->udev.event)
+        u->card->core->mainloop->io_free(u->udev.event);
+
+    if (u->udev.monitor)
+        udev_monitor_unref(u->udev.monitor);
+
+    if (u->udev.udev)
+        udev_unref(u->udev.udev);
+
+    if (u->h2w)
+        droid_switch_free(u->h2w);
+
+    pa_xfree(u);
+}

--- a/src/droid/droid-extcon.h
+++ b/src/droid/droid-extcon.h
@@ -1,0 +1,32 @@
+#ifndef foodroidextconhfoo
+#define foodroidextconhfoo
+
+/***
+  This file is part of PulseAudio.
+
+  Copyright (C) 2013 Canonical Ltd.
+  Contact: David Henningsson
+
+  PulseAudio is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published
+  by the Free Software Foundation; either version 2.1 of the License,
+  or (at your option) any later version.
+
+  PulseAudio is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with PulseAudio; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+typedef struct pa_droid_extcon pa_droid_extcon;
+
+pa_droid_extcon *pa_droid_extcon_new(pa_core *, pa_card *);
+
+void pa_droid_extcon_free(pa_droid_extcon *);
+
+#endif

--- a/src/droid/droid-extevdev.c
+++ b/src/droid/droid-extevdev.c
@@ -1,0 +1,256 @@
+/***
+  This file is part of PulseAudio.
+
+  Copyright (C) 2019 UBports foundation.
+  Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
+
+  PulseAudio is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published
+  by the Free Software Foundation; either version 2.1 of the License,
+  or (at your option) any later version.
+
+  PulseAudio is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with PulseAudio; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#define _GNU_SOURCE // For scandir and versionsort
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include <libevdev/libevdev.h>
+
+#include <pulsecore/core-util.h>
+#include <pulsecore/device-port.h>
+
+#include "droid-extevdev.h"
+
+#define DEV_INPUT_EVENT "/dev/input"
+#define EVENT_DEV_NAME "event"
+
+struct pa_droid_extevdev {
+    pa_card *card;
+    struct libevdev *evdev_dev;
+    pa_io_event *event;
+
+    /* Switch values */
+    bool sw_headphone_insert : 1;
+    bool sw_microphone_insert : 1;
+    bool sw_lineout_insert : 1;
+};
+
+static int is_event_device(const struct dirent *dir) {
+    return strncmp(EVENT_DEV_NAME, dir->d_name, 5) == 0;
+}
+
+static struct libevdev *find_switch_evdev(void) {
+    struct dirent **namelist;
+    int ndev, i;
+    struct libevdev *ret = NULL;
+
+    ndev = scandir(DEV_INPUT_EVENT, &namelist, is_event_device, versionsort);
+
+    for (i = 0; i < ndev; i++) {
+        char fname[PATH_MAX];
+        int fd;
+        struct libevdev *dev;
+        int err;
+
+        snprintf(fname, sizeof(fname), "%s/%s",
+                 DEV_INPUT_EVENT, namelist[i]->d_name);
+
+        pa_log_debug("Checking %s for headphone switch.", fname);
+
+        fd = open(fname, O_RDONLY|O_NONBLOCK);
+        if (fd < 0) {
+            err = errno;
+            pa_log_warn("Unable to open device %s, ignored: %s",
+                        fname, strerror(err));
+            continue;
+        }
+
+        if ((err = libevdev_new_from_fd(fd, &dev)) < 0) {
+            err = -err;
+            pa_log_warn("Unable to create libevdev device for %s, ignored: %s",
+                        fname, strerror(err));
+            close(fd);
+            continue;
+        }
+
+        if (libevdev_has_event_code(dev, EV_SW, SW_HEADPHONE_INSERT)) {
+            ret = dev;
+            break;
+        }
+
+        libevdev_free(dev);
+        close(fd);
+    }
+
+    for (i = 0; i < ndev; i++)
+        free(namelist[i]);
+    free(namelist);
+
+    return ret;
+}
+
+/* Put the port we want to be active (for each direction) later in the list.
+ * module-switch-on-port-available will switch to the available port as it
+ * become available, so the last port available will stay active. */
+
+static const char *headphone_ports[] = {
+    "output-wired_headphone",
+};
+
+static const char *headset_ports[] = {
+    "output-wired_headset",
+    "input-wired_headset",
+};
+
+static void notify_ports(pa_droid_extevdev *u) {
+    unsigned int i;
+
+    pa_available_t has_headphone =
+        ((u->sw_headphone_insert || u->sw_lineout_insert)
+        && !u->sw_microphone_insert) ? PA_AVAILABLE_YES : PA_AVAILABLE_NO;
+
+    for (i = 0; i < PA_ELEMENTSOF(headphone_ports); i++) {
+        pa_device_port *p = pa_hashmap_get(u->card->ports, headphone_ports[i]);
+        if (p)
+            pa_device_port_set_available(p, has_headphone);
+    }
+
+    pa_available_t has_headset =
+        ((u->sw_headphone_insert || u->sw_lineout_insert)
+        && u->sw_microphone_insert) ? PA_AVAILABLE_YES : PA_AVAILABLE_NO;
+
+    for (i = 0; i < PA_ELEMENTSOF(headset_ports); i++) {
+        pa_device_port *p = pa_hashmap_get(u->card->ports, headset_ports[i]);
+        if (p)
+            pa_device_port_set_available(p, has_headset);
+    }
+}
+
+/* Called from IO context */
+static void evdev_cb(pa_mainloop_api *a, pa_io_event *e, int fd,
+                     pa_io_event_flags_t events, void *userdata) {
+    pa_droid_extevdev *u = userdata;
+
+    unsigned int flags = LIBEVDEV_READ_FLAG_NORMAL;
+    int err;
+    struct input_event ev;
+
+    while (1) {
+        err = libevdev_next_event(u->evdev_dev, flags, &ev);
+
+        if (err == -EAGAIN) {
+            if (flags == LIBEVDEV_READ_FLAG_SYNC) {
+                /* Switch the flag back to read next normal events. */
+                flags = LIBEVDEV_READ_FLAG_NORMAL;
+                continue;
+            } else {
+                /* We run out of event. */
+                break;
+            }
+        } else if (err == LIBEVDEV_READ_STATUS_SYNC) {
+            if (flags == LIBEVDEV_READ_FLAG_NORMAL) {
+                /* Handle dropped events by switching to SYNC mode. */
+                flags = LIBEVDEV_READ_FLAG_SYNC;
+                continue;
+            } /* Otherwise we're in the middle of handling it. */
+        } else if (err < 0) {
+            pa_log_error("Error in reading the event from evdev: %s",
+                        strerror(-err));
+            /* TODO: Should we just remove the event source? */
+            break;
+        }
+
+        /* ev now contains the current event. */
+        if (ev.type == EV_SW) {
+            switch (ev.code) {
+                case SW_HEADPHONE_INSERT:
+                    u->sw_headphone_insert = ev.value;
+                    break;
+                case SW_MICROPHONE_INSERT:
+                    u->sw_microphone_insert = ev.value;
+                    break;
+                case SW_LINEOUT_INSERT:
+                    u->sw_lineout_insert = ev.value;
+                    break;
+                default:
+                    /* Ignore unknown switch. */
+                    break;
+            }
+        } else if (ev.type == EV_SYN && ev.code == SYN_REPORT) {
+            notify_ports(u);
+        }
+    }
+}
+
+static void read_initial_switch_values(pa_droid_extevdev *u) {
+    /* A local variable is needed because sw_* are bitfields. */
+    int value;
+
+#define INIT_SW(code, sw_var) \
+    if (libevdev_fetch_event_value(u->evdev_dev, EV_SW, code, &value)) \
+        u->sw_var = value; \
+    else \
+        u->sw_var = false;
+
+    INIT_SW(SW_HEADPHONE_INSERT, sw_headphone_insert)
+    INIT_SW(SW_MICROPHONE_INSERT, sw_microphone_insert)
+    INIT_SW(SW_LINEOUT_INSERT, sw_lineout_insert)
+
+#undef INIT_SW
+
+    notify_ports(u);
+}
+
+pa_droid_extevdev *pa_droid_extevdev_new(pa_core *core, pa_card *card) {
+    pa_droid_extevdev *u = pa_xnew0(pa_droid_extevdev, 1);
+
+    pa_assert(core);
+    pa_assert(card);
+
+    u->card = card;
+    u->evdev_dev = find_switch_evdev();
+
+    if (!u->evdev_dev)
+        goto fail;
+
+    pa_assert_se(u->event = core->mainloop->io_new(core->mainloop,
+                libevdev_get_fd(u->evdev_dev), PA_IO_EVENT_INPUT, evdev_cb, u));
+
+    read_initial_switch_values(u);
+
+    return u;
+
+fail:
+    pa_droid_extevdev_free(u);
+    return NULL;
+}
+
+void pa_droid_extevdev_free(pa_droid_extevdev *u) {
+    if (u->event)
+        u->card->core->mainloop->io_free(u->event);
+
+    if (u->evdev_dev) {
+        int fd = libevdev_get_fd(u->evdev_dev);
+        libevdev_free(u->evdev_dev);
+        close(fd);
+    }
+
+    pa_xfree(u);
+}

--- a/src/droid/droid-extevdev.c
+++ b/src/droid/droid-extevdev.c
@@ -4,6 +4,9 @@
   Copyright (C) 2019 UBports foundation.
   Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
 
+  Copyright (C) 2026 Jolla Mobile Ltd
+  Author(s): Enni Hämäläinen <enni.hamalainen@jolla.com>
+
   PulseAudio is free software; you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published
   by the Free Software Foundation; either version 2.1 of the License,
@@ -20,91 +23,43 @@
   USA.
 ***/
 
-#define _GNU_SOURCE // For scandir and versionsort
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
 
-#include <stdio.h>
 #include <dirent.h>
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <linux/input.h>
+#include <linux/types.h>
 
-#include <libevdev/libevdev.h>
-
-#include <pulsecore/core-util.h>
 #include <pulsecore/device-port.h>
+#include <pulsecore/card.h>
+#include <pulsecore/core-error.h>
+#include <pulsecore/core-util.h>
 
 #include "droid-extevdev.h"
 
 #define DEV_INPUT_EVENT "/dev/input"
-#define EVENT_DEV_NAME "event"
 
 struct pa_droid_extevdev {
     pa_card *card;
-    struct libevdev *evdev_dev;
+    int fd;
+    int fd_type;
     pa_io_event *event;
 
     /* Switch values */
-    bool sw_headphone_insert : 1;
-    bool sw_microphone_insert : 1;
-    bool sw_lineout_insert : 1;
+    int sw_headphone_insert;
+    int sw_microphone_insert;
+    int sw_lineout_insert;
 };
 
-static int is_event_device(const struct dirent *dir) {
-    return strncmp(EVENT_DEV_NAME, dir->d_name, 5) == 0;
-}
+#define BITS_PER_U32 (sizeof(uint32_t) * 8)
+#define NBITS(x) ((((x) - 1) / BITS_PER_U32) + 1)
 
-static struct libevdev *find_switch_evdev(void) {
-    struct dirent **namelist;
-    int ndev, i;
-    struct libevdev *ret = NULL;
-
-    ndev = scandir(DEV_INPUT_EVENT, &namelist, is_event_device, versionsort);
-
-    for (i = 0; i < ndev; i++) {
-        char fname[PATH_MAX];
-        int fd;
-        struct libevdev *dev;
-        int err;
-
-        snprintf(fname, sizeof(fname), "%s/%s",
-                 DEV_INPUT_EVENT, namelist[i]->d_name);
-
-        pa_log_debug("Checking %s for headphone switch.", fname);
-
-        fd = open(fname, O_RDONLY|O_NONBLOCK);
-        if (fd < 0) {
-            err = errno;
-            pa_log_warn("Unable to open device %s, ignored: %s",
-                        fname, strerror(err));
-            continue;
-        }
-
-        if ((err = libevdev_new_from_fd(fd, &dev)) < 0) {
-            err = -err;
-            pa_log_warn("Unable to create libevdev device for %s, ignored: %s",
-                        fname, strerror(err));
-            close(fd);
-            continue;
-        }
-
-        if (libevdev_has_event_code(dev, EV_SW, SW_HEADPHONE_INSERT)) {
-            ret = dev;
-            break;
-        }
-
-        libevdev_free(dev);
-        close(fd);
-    }
-
-    for (i = 0; i < ndev; i++)
-        free(namelist[i]);
-    free(namelist);
-
-    return ret;
-}
+#define TEST_BIT(n, bits) (((bits)[(n) / BITS_PER_U32]) &       \
+                           (0x1 << ((n) % BITS_PER_U32)))
 
 /* Put the port we want to be active (for each direction) later in the list.
  * module-switch-on-port-available will switch to the available port as it
@@ -143,97 +98,171 @@ static void notify_ports(pa_droid_extevdev *u) {
     }
 }
 
-/* Called from IO context */
-static void evdev_cb(pa_mainloop_api *a, pa_io_event *e, int fd,
-                     pa_io_event_flags_t events, void *userdata) {
+static void event_callback(pa_mainloop_api *io, pa_io_event *e, int fd, pa_io_event_flags_t events, void *userdata) {
     pa_droid_extevdev *u = userdata;
 
-    unsigned int flags = LIBEVDEV_READ_FLAG_NORMAL;
-    int err;
-    struct input_event ev;
-
-    while (1) {
-        err = libevdev_next_event(u->evdev_dev, flags, &ev);
-
-        if (err == -EAGAIN) {
-            if (flags == LIBEVDEV_READ_FLAG_SYNC) {
-                /* Switch the flag back to read next normal events. */
-                flags = LIBEVDEV_READ_FLAG_NORMAL;
-                continue;
-            } else {
-                /* We run out of event. */
-                break;
-            }
-        } else if (err == LIBEVDEV_READ_STATUS_SYNC) {
-            if (flags == LIBEVDEV_READ_FLAG_NORMAL) {
-                /* Handle dropped events by switching to SYNC mode. */
-                flags = LIBEVDEV_READ_FLAG_SYNC;
-                continue;
-            } /* Otherwise we're in the middle of handling it. */
-        } else if (err < 0) {
-            pa_log_error("Error in reading the event from evdev: %s",
-                        strerror(-err));
-            /* TODO: Should we just remove the event source? */
-            break;
-        }
-
-        /* ev now contains the current event. */
-        if (ev.type == EV_SW) {
-            switch (ev.code) {
-                case SW_HEADPHONE_INSERT:
-                    u->sw_headphone_insert = ev.value;
-                    break;
-                case SW_MICROPHONE_INSERT:
-                    u->sw_microphone_insert = ev.value;
-                    break;
-                case SW_LINEOUT_INSERT:
-                    u->sw_lineout_insert = ev.value;
-                    break;
-                default:
-                    /* Ignore unknown switch. */
-                    break;
-            }
-        } else if (ev.type == EV_SYN && ev.code == SYN_REPORT) {
-            notify_ports(u);
-        }
+    if (events & PA_IO_EVENT_HANGUP) {
+        pa_log("input device closed unexpectedly");
+        return;
     }
+
+    if (events & PA_IO_EVENT_ERROR) {
+        pa_log("input device had an I/O error");
+        return;
+    }
+
+    if (events & PA_IO_EVENT_INPUT) {
+        struct input_event ev;
+
+        if (pa_loop_read(u->fd, &ev, sizeof(ev), &u->fd_type) <= 0) {
+            pa_log("Failed to read from event device: %s", pa_cstrerror(errno));
+            return;
+        }
+
+        if (ev.type != EV_SW && ev.type != EV_SYN) {
+            pa_log("Ignoring input event type %d", ev.type);
+            return;
+        }
+
+        if (ev.type == EV_SYN) {
+            notify_ports(u);
+            return;
+        }
+
+        #define LOG_SW(x) pa_log_debug(#x " %d", u->x)
+
+        switch (ev.code) {
+            case SW_HEADPHONE_INSERT:   u->sw_headphone_insert  = ev.value; LOG_SW(sw_headphone_insert);    break;
+            case SW_MICROPHONE_INSERT:  u->sw_microphone_insert = ev.value; LOG_SW(sw_microphone_insert);   break;
+            case SW_LINEOUT_INSERT:     u->sw_lineout_insert    = ev.value; LOG_SW(sw_lineout_insert);      break;
+        }
+
+        #undef LOG_SW
+    }
+    return;
 }
 
-static void read_initial_switch_values(pa_droid_extevdev *u) {
-    /* A local variable is needed because sw_* are bitfields. */
-    int value;
+static void query_initial_state(pa_droid_extevdev *u)
+{
+    uint32_t bitmask[NBITS(KEY_MAX)];
 
-#define INIT_SW(code, sw_var) \
-    if (libevdev_fetch_event_value(u->evdev_dev, EV_SW, code, &value)) \
-        u->sw_var = value; \
-    else \
-        u->sw_var = false;
+    memset(bitmask, 0, sizeof(bitmask));
 
-    INIT_SW(SW_HEADPHONE_INSERT, sw_headphone_insert)
-    INIT_SW(SW_MICROPHONE_INSERT, sw_microphone_insert)
-    INIT_SW(SW_LINEOUT_INSERT, sw_lineout_insert)
+    if (ioctl(u->fd, EVIOCGSW(sizeof(bitmask)), &bitmask) < 0) {
+        pa_log("failed to query current connected state: %s",
+               pa_cstrerror(errno));
+        return;
+    }
 
-#undef INIT_SW
+    u->sw_headphone_insert      = TEST_BIT(SW_HEADPHONE_INSERT    , bitmask);
+    u->sw_microphone_insert     = TEST_BIT(SW_MICROPHONE_INSERT   , bitmask);
+    u->sw_lineout_insert        = TEST_BIT(SW_LINEOUT_INSERT      , bitmask);
+
+    pa_log_debug("headphone is %sconnected" , u->sw_headphone_insert  ? "" : "dis");
+    pa_log_debug("microphone is %sconnected", u->sw_microphone_insert ? "" : "dis");
+    pa_log_debug("lineout is %sconnected"   , u->sw_lineout_insert    ? "" : "dis");
 
     notify_ports(u);
 }
 
-pa_droid_extevdev *pa_droid_extevdev_new(pa_core *core, pa_card *card) {
+static bool check_device(int fd)
+{
+    unsigned long evbit[NBITS(EV_MAX)];
+    unsigned long swbit[NBITS(SW_MAX)];
+
+    memset(&evbit, 0, sizeof(evbit));
+    memset(&swbit, 0, sizeof(swbit));
+
+    /* Query supported event types */
+    if (ioctl(fd, EVIOCGBIT(0, sizeof(evbit)), evbit) < 0) {
+        pa_log_warn("Could not get features: %s", pa_cstrerror(errno));
+        return false;
+    }
+
+    if (!TEST_BIT(EV_SW, evbit)) {
+        pa_log_debug("Device does NOT support EV_SW");
+        return false;
+    }
+
+    /* Query supported switch codes */
+    if (ioctl(fd, EVIOCGBIT(EV_SW, sizeof(swbit)), swbit) < 0) {
+        pa_log_warn("Could not get switch codes: %s", pa_cstrerror(errno));
+        return false;
+    }
+
+    if (!TEST_BIT(SW_HEADPHONE_INSERT, swbit)) {
+        pa_log_debug("Device does NOT have SW_HEADPHONE_INSERT");
+        return false;
+    }
+
+    return true;
+}
+
+static int find_input_device()
+{
+    DIR *dir;
+    struct dirent *de;
+    char path[PATH_MAX];
+    int fd = -1;
+
+    if (!(dir = opendir(DEV_INPUT_EVENT))) {
+        pa_log("failed to open directory " DEV_INPUT_EVENT);
+        return fd;
+    }
+
+    while ((de = readdir(dir)) != NULL) {
+        if (de->d_type != DT_CHR && de->d_type != DT_LNK)
+            continue;
+
+        pa_snprintf(path, sizeof(path), DEV_INPUT_EVENT "/%s", de->d_name);
+
+        if ((fd = open(path, O_RDONLY)) < 0) {
+            pa_log("failed to open %s for reading", path);
+            continue;
+        }
+
+        if (check_device(fd)) {
+            pa_log_info("input device found at %s", path);
+            break;
+        } else {
+            close(fd);
+            fd = -1;
+        }
+    }
+
+    closedir(dir);
+
+    return fd;
+}
+
+static bool setup(pa_droid_extevdev *u) {
+    u->fd = find_input_device();
+
+    if (u->fd < 0) {
+        pa_log("could not start input device detection.");
+        return false;
+    }
+
+    u->event = u->card->core->mainloop->io_new(u->card->core->mainloop,
+                                               u->fd,
+                                               PA_IO_EVENT_INPUT|PA_IO_EVENT_HANGUP|PA_IO_EVENT_ERROR,
+                                               event_callback,
+                                               u);
+
+    query_initial_state(u);
+
+    return true;
+}
+
+pa_droid_extevdev *pa_droid_extevdev_new(pa_card *card) {
     pa_droid_extevdev *u = pa_xnew0(pa_droid_extevdev, 1);
 
-    pa_assert(core);
     pa_assert(card);
 
     u->card = card;
-    u->evdev_dev = find_switch_evdev();
 
-    if (!u->evdev_dev)
+    if (!setup(u))
         goto fail;
-
-    pa_assert_se(u->event = core->mainloop->io_new(core->mainloop,
-                libevdev_get_fd(u->evdev_dev), PA_IO_EVENT_INPUT, evdev_cb, u));
-
-    read_initial_switch_values(u);
 
     return u;
 
@@ -243,14 +272,10 @@ fail:
 }
 
 void pa_droid_extevdev_free(pa_droid_extevdev *u) {
-    if (u->event)
-        u->card->core->mainloop->io_free(u->event);
+    if (!u)
+        return;
 
-    if (u->evdev_dev) {
-        int fd = libevdev_get_fd(u->evdev_dev);
-        libevdev_free(u->evdev_dev);
-        close(fd);
-    }
+    u->card->core->mainloop->io_free(u->event);
 
     pa_xfree(u);
 }

--- a/src/droid/droid-extevdev.h
+++ b/src/droid/droid-extevdev.h
@@ -5,6 +5,9 @@
   Copyright (C) 2019 UBports foundation.
   Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
 
+  Copyright (C) 2026 Jolla Mobile Ltd
+  Author(s): Enni Hämäläinen <enni.hamalainen@jolla.com>
+
   PulseAudio is free software; you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published
   by the Free Software Foundation; either version 2.1 of the License,
@@ -23,7 +26,7 @@
 
 typedef struct pa_droid_extevdev pa_droid_extevdev;
 
-pa_droid_extevdev *pa_droid_extevdev_new(pa_core *, pa_card *);
+pa_droid_extevdev *pa_droid_extevdev_new(pa_card *);
 
 void pa_droid_extevdev_free(pa_droid_extevdev *);
 

--- a/src/droid/droid-extevdev.h
+++ b/src/droid/droid-extevdev.h
@@ -1,0 +1,30 @@
+#ifndef foodroidextevdevhfoo
+#define foodroidextevdevhfoo
+
+/***
+  Copyright (C) 2019 UBports foundation.
+  Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
+
+  PulseAudio is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published
+  by the Free Software Foundation; either version 2.1 of the License,
+  or (at your option) any later version.
+
+  PulseAudio is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with PulseAudio; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+typedef struct pa_droid_extevdev pa_droid_extevdev;
+
+pa_droid_extevdev *pa_droid_extevdev_new(pa_core *, pa_card *);
+
+void pa_droid_extevdev_free(pa_droid_extevdev *);
+
+#endif

--- a/src/droid/droid-extusbdev.c
+++ b/src/droid/droid-extusbdev.c
@@ -1,0 +1,379 @@
+/***
+  Copyright (C) 2026 Jolla Mobile Ltd
+  Author(s): Enni Hämäläinen <enni.hamalainen@jolla.com>
+
+  PulseAudio is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published
+  by the Free Software Foundation; either version 2.1 of the License,
+  or (at your option) any later version.
+
+  PulseAudio is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with PulseAudio; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <unistd.h>
+#include <linux/input.h>
+#include <linux/types.h>
+
+#include <pulsecore/device-port.h>
+#include <pulsecore/card.h>
+#include <pulsecore/core-error.h>
+#include <pulsecore/core-util.h>
+
+#include <alsa/asoundlib.h>
+#include <libudev.h>
+
+#include <droid/droid-util.h>
+
+#include "droid-extusbdev.h"
+
+#define MAX_SAMPLE_RATES (17)
+
+struct pa_droid_extusbdev {
+    pa_card *card;
+    pa_droid_hw_module *hw_module;
+
+    struct udev* udev;
+    struct udev_monitor *monitor;
+    pa_io_event *udev_io;
+
+    pa_hashmap *cards;
+};
+
+typedef struct {
+    bool playback;
+    bool capture;
+    int card;
+    int device;
+} audio_device_caps_t;
+
+typedef struct {
+    char *devpath;
+    audio_device_caps_t caps;
+} usb_card_t;
+
+static void handle_usb_device_added(pa_droid_extusbdev *u, struct udev_device *dev);
+
+static const char *usb_headset_ports[] = {
+    "output-usb_headset",
+    "input-usb_headset",
+    NULL
+};
+
+static const char *usb_device_ports[] = {
+    "output-usb_device",
+    NULL
+};
+
+static const char *usb_mic_ports[] = {
+    "input-usb_device",
+    NULL
+};
+
+static int get_card_id(const char *path)
+{
+    const char *last;
+    int id = -1;
+
+    if (!path)
+        return id;
+
+    if (!(last = strrchr(path, '/')))
+        return id;
+
+    if (strlen(last) < 6 || !pa_startswith(last, "/card"))
+        return id;
+
+    pa_atoi(last + 5, &id);
+
+    return id;
+}
+
+static const char *card_type_to_string(audio_device_caps_t *caps) {
+    if (caps->playback && caps->capture)
+        return "headset";
+
+    if (caps->playback || caps->capture)
+        return "device";
+
+    return "invalid";
+}
+
+static void inspect_card(pa_droid_extusbdev *u, int card, audio_device_caps_t *devcaps)
+{
+    snd_ctl_t *ctl;
+    char ctlname[32];
+
+    memset(devcaps, 0, sizeof(audio_device_caps_t));
+
+    snprintf(ctlname, sizeof(ctlname), "hw:%d", card);
+
+    if (snd_ctl_open(&ctl, ctlname, 0) < 0)
+        return;
+
+    int dev = -1;
+
+    /* Lookup devices until one with both playback and capture is
+     * found. If just one is available we iterate through all. */
+    while (!devcaps->playback && !devcaps->capture) {
+        if (snd_ctl_pcm_next_device(ctl, &dev) < 0)
+            break;
+
+        if (dev < 0)
+            break;
+
+        char pcmname[64];
+        snd_pcm_t *pcm;
+
+        pa_snprintf(pcmname, sizeof(pcmname), "hw:%d,%d", card, dev);
+
+        if (snd_pcm_open(&pcm,
+                         pcmname,
+                         SND_PCM_STREAM_PLAYBACK,
+                         SND_PCM_NONBLOCK) >= 0) {
+            devcaps->playback = true;
+            snd_pcm_close(pcm);
+        }
+
+        if (snd_pcm_open(&pcm,
+                         pcmname,
+                         SND_PCM_STREAM_CAPTURE,
+                         SND_PCM_NONBLOCK) >= 0) {
+            devcaps->capture = true;
+            snd_pcm_close(pcm);
+        }
+
+        devcaps->card = card;
+        devcaps->device = dev;
+    }
+
+    snd_ctl_close(ctl);
+}
+
+static void enumerate_existing(pa_droid_extusbdev *u, struct udev *udev)
+{
+    pa_log_debug("Check existing USB devices");
+
+    struct udev_enumerate *e = udev_enumerate_new(udev);
+
+    udev_enumerate_add_match_subsystem(e, "sound");
+    udev_enumerate_scan_devices(e);
+
+    struct udev_list_entry *devices = udev_enumerate_get_list_entry(e);
+    struct udev_list_entry *entry;
+
+    udev_list_entry_foreach(entry, devices) {
+        const char *path = udev_list_entry_get_name(entry);
+        struct udev_device *dev = udev_device_new_from_syspath(udev, path);
+
+        if (!dev)
+            continue;
+
+        struct udev_device *parent = udev_device_get_parent_with_subsystem_devtype(dev, "usb", "usb_device");
+
+        if (parent)
+            handle_usb_device_added(u, dev);
+
+        udev_device_unref(dev);
+    }
+
+    udev_enumerate_unref(e);
+}
+
+static void connect_card(pa_droid_extusbdev *u, usb_card_t *card, bool connect) {
+    const char **ports;
+
+    pa_assert(u);
+    pa_assert(card);
+
+    if (card->caps.playback && card->caps.capture) {
+        ports = usb_headset_ports;
+    } else if (card->caps.playback) {
+        ports = usb_device_ports;
+    } else if (card->caps.capture) {
+        ports = usb_mic_ports;
+    } else {
+        pa_log("No devices to %sconnect.", connect ? "" : "dis");
+        return;
+    }
+
+    pa_log_info("USB %s (hw:%d,%d) %sconnected", card_type_to_string(&card->caps),
+                                                 card->caps.card, 
+                                                 card->caps.device,
+                                                 connect ? "" : "dis");
+
+    for (int i = 0; ports[i]; i++) {
+        pa_device_port *p = pa_hashmap_get(u->card->ports, ports[i]);
+        if (p) {
+            if (connect)
+                pa_droid_device_port_set_usb_connected(p, card->caps.card, card->caps.device);
+            else
+                pa_droid_device_port_set_usb_disconnected(p);
+            pa_device_port_set_available(p, connect ? PA_AVAILABLE_YES : PA_AVAILABLE_NO);
+        }
+    }
+}
+
+static void handle_usb_device_added(pa_droid_extusbdev *u, struct udev_device *dev) {
+    int card_id = -1;
+    audio_device_caps_t caps = {0};
+
+    if (pa_hashmap_get(u->cards, udev_device_get_devpath(dev)))
+        return;
+
+    card_id = get_card_id(udev_device_get_devpath(dev));
+
+    if (card_id >= 0)
+        inspect_card(u, card_id, &caps);
+
+    if (!caps.playback && !caps.capture)
+        return;
+
+    usb_card_t *card = pa_xnew0(usb_card_t, 1);
+    card->devpath = pa_xstrdup(udev_device_get_devpath(dev));
+    card->caps = caps;
+
+    pa_hashmap_put(u->cards, card->devpath, card);
+
+    pa_log_info("USB %s added, %s", card_type_to_string(&card->caps), udev_device_get_devpath(dev));
+
+    connect_card(u, card, true);
+}
+
+static void handle_usb_device_removed(pa_droid_extusbdev *u, struct udev_device *dev) {
+    usb_card_t *card;
+
+    if (!(card = pa_hashmap_get(u->cards, udev_device_get_devpath(dev))))
+        return;
+
+    pa_log_info("USB %s removed, %s", card_type_to_string(&card->caps), card->devpath);
+
+    connect_card(u, card, false);
+
+    pa_hashmap_remove_and_free(u->cards, udev_device_get_devpath(dev));
+}
+
+static void monitor_cb(pa_mainloop_api *a,
+                       pa_io_event *e,
+                       int fd,
+                       pa_io_event_flags_t events,
+                       void *userdata) {
+
+    struct pa_droid_extusbdev *u = userdata;
+    struct udev_device *dev = NULL;
+
+    pa_assert(a);
+
+    if (!(dev = udev_monitor_receive_device(u->monitor))) {
+        pa_log("Failed to get udev device object from monitor.");
+        return;
+    }
+
+    if (udev_device_get_property_value(dev, "PULSE_IGNORE")) {
+        pa_log_debug("Ignoring %s, because marked so.", udev_device_get_devpath(dev));
+        return;
+    }
+
+    const char *ff;
+    if ((ff = udev_device_get_property_value(dev, "SOUND_CLASS")) &&
+        pa_streq(ff, "modem")) {
+        pa_log_debug("Ignoring %s, because it is a modem.", udev_device_get_devpath(dev));
+        return;
+    }
+
+    const char *action = udev_device_get_action(dev);
+
+    if (pa_safe_streq(action, "remove")) {
+        handle_usb_device_removed(u, dev);
+    } else if (pa_safe_streq(action, "change") || udev_device_get_property_value(dev, "SOUND_INITIALIZED")) {
+        struct udev_device *parent = udev_device_get_parent_with_subsystem_devtype(dev, "usb", "usb_device");
+
+        if (!parent) {
+            /* Not USB audio device. */
+            goto done;
+        }
+
+        handle_usb_device_added(u, dev);
+    }
+
+done:
+    udev_device_unref(dev);
+}
+
+static void usb_card_free(usb_card_t *card) {
+    pa_xfree(card->devpath);
+    pa_xfree(card);
+}
+
+pa_droid_extusbdev *pa_droid_extusbdev_new(pa_droid_hw_module *hw, pa_card *c) {
+    pa_droid_extusbdev *u = pa_xnew0(pa_droid_extusbdev, 1);
+
+    u->card = c;
+    u->hw_module = hw;
+
+    int fd;
+
+    if (!(u->udev = udev_new())) {
+        pa_log("Failed to initialize udev library.");
+        goto fail;
+    }
+
+    u->cards = pa_hashmap_new_full(pa_idxset_string_hash_func,
+                                   pa_idxset_string_compare_func,
+                                   NULL,
+                                   (pa_free_cb_t) usb_card_free);
+
+    enumerate_existing(u, u->udev);
+
+    if (!(u->monitor = udev_monitor_new_from_netlink(u->udev, "udev"))) {
+        pa_log("Failed to initialize monitor.");
+        goto fail;
+    }
+
+    if (udev_monitor_filter_add_match_subsystem_devtype(u->monitor, "sound", NULL) < 0) {
+        pa_log("Failed to subscribe to sound devices.");
+        goto fail;
+    }
+
+    errno = 0;
+    if (udev_monitor_enable_receiving(u->monitor) < 0) {
+        pa_log("Failed to enable udev monitor: %s", pa_cstrerror(errno));
+        goto fail;
+    }
+
+    if ((fd = udev_monitor_get_fd(u->monitor)) < 0) {
+        pa_log("Failed to get udev monitor fd.");
+        goto fail;
+    }
+
+    pa_assert_se(u->udev_io = u->card->core->mainloop->io_new(u->card->core->mainloop, fd, PA_IO_EVENT_INPUT, monitor_cb, u));
+
+fail:
+    return u;
+}
+
+void pa_droid_extusbdev_free(pa_droid_extusbdev *u) {
+    if (!u)
+        return;
+
+    pa_xfree(u);
+}
+

--- a/src/droid/droid-extusbdev.h
+++ b/src/droid/droid-extusbdev.h
@@ -1,0 +1,32 @@
+#ifndef foodroidextusbdevhfoo
+#define foodroidextusbdevhfoo
+
+/***
+  Copyright (C) 2026 Jolla Mobile Ltd.
+  Author(s): Enni Hämäläinen <enni.hamalainen@jolla.com>
+
+  PulseAudio is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published
+  by the Free Software Foundation; either version 2.1 of the License,
+  or (at your option) any later version.
+
+  PulseAudio is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with PulseAudio; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#include <droid/droid-util.h>
+
+typedef struct pa_droid_extusbdev pa_droid_extusbdev;
+
+pa_droid_extusbdev *pa_droid_extusbdev_new(pa_droid_hw_module *hw, pa_card *c);
+
+void pa_droid_extusbdev_free(pa_droid_extusbdev *);
+
+#endif

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Jolla Ltd.
+ * Copyright (C) 2013-2026 Jolla Mobile Ltd
  *
  * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
  *
@@ -925,7 +925,7 @@ pa_sink *pa_droid_sink_new(pa_module *m,
     dm_config_port *mix_port = NULL;
     dm_config_port *device_port = NULL;
     bool deferred_volume = false;
-    bool voice_virtual_stream = false;
+    bool voice_virtual_stream = true;
     char *thread_name = NULL;
     pa_sink_new_data data;
     const char *module_id = NULL;

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -87,8 +87,10 @@ struct userdata {
 
     bool use_hw_volume;
     bool use_voice_volume;
+    bool voice_virtual_stream;
     char *voice_property_key;
     char *voice_property_value;
+    pa_sink_input *voice_virtual_sink_input;
     pa_hook_slot *sink_input_volume_changed_hook_slot;
 
     pa_hook_slot *sink_input_put_hook_slot;
@@ -671,6 +673,74 @@ static pa_hook_result_t sink_input_volume_changed_hook_cb(pa_core *c, pa_sink_in
     return PA_HOOK_OK;
 }
 
+/* For voice virtual stream, based on meego-mainvolume */
+static void sink_input_kill_cb(pa_sink_input *i) {
+    struct userdata *u;
+
+    pa_sink_input_assert_ref(i);
+    pa_assert_se(u = i->userdata);
+
+    pa_sink_input_unlink(u->voice_virtual_sink_input);
+    pa_sink_input_unref(u->voice_virtual_sink_input);
+    u->voice_virtual_sink_input = NULL;
+}
+
+/* no-op */
+static int sink_input_pop_cb(pa_sink_input *i, size_t nbytes, pa_memchunk *chunk) {
+    return 0;
+}
+
+/* no-op */
+static void sink_input_process_rewind_cb(pa_sink_input *i, size_t nbytes) {
+}
+
+static void create_voice_virtual_stream(struct userdata *u) {
+    pa_sink_input_new_data data;
+
+    pa_assert(u);
+
+    if (!u->voice_virtual_stream || u->voice_virtual_sink_input)
+        return;
+
+    pa_sink_input_new_data_init(&data);
+
+    data.driver = __FILE__;
+    data.module = u->module;
+    pa_proplist_sets(data.proplist, PA_PROP_MEDIA_NAME, "Virtual Stream for Voice Volume Control (Droid)");
+    pa_proplist_sets(data.proplist, PA_PROP_MEDIA_ROLE, "phone");
+    pa_sink_input_new_data_set_sample_spec(&data, &u->core->default_sample_spec);
+    pa_sink_input_new_data_set_channel_map(&data, &u->core->default_channel_map);
+    data.flags = PA_SINK_INPUT_START_CORKED | PA_SINK_INPUT_NO_REMAP | PA_SINK_INPUT_NO_REMIX;
+
+    pa_sink_input_new(&u->voice_virtual_sink_input, u->module->core, &data);
+    pa_sink_input_new_data_done(&data);
+
+    if (!u->voice_virtual_sink_input) {
+        pa_log_warn("Failed to create virtual sink input.");
+        return;
+    }
+
+    u->voice_virtual_sink_input->userdata = u;
+    u->voice_virtual_sink_input->kill = sink_input_kill_cb;
+    u->voice_virtual_sink_input->pop = sink_input_pop_cb;
+    u->voice_virtual_sink_input->process_rewind = sink_input_process_rewind_cb;
+
+    pa_sink_input_put(u->voice_virtual_sink_input);
+
+    pa_log_debug("Created virtual sink input for voice call volume control.");
+}
+
+static void destroy_voice_virtual_stream(struct userdata *u) {
+    pa_assert(u);
+
+    if (!u->voice_virtual_sink_input)
+        return;
+
+    sink_input_kill_cb(u->voice_virtual_sink_input);
+
+    pa_log_debug("Removed virtual stream.");
+}
+
 /* Called from main thread */
 void pa_droid_sink_set_voice_control(pa_sink* sink, bool enable) {
     pa_sink_input *i;
@@ -698,6 +768,9 @@ void pa_droid_sink_set_voice_control(pa_sink* sink, bool enable) {
 
         pa_assert(!u->sink_input_volume_changed_hook_slot);
 
+        if (u->voice_virtual_stream)
+            create_voice_virtual_stream(u);
+
         u->sink_input_volume_changed_hook_slot = pa_hook_connect(&u->core->hooks[PA_CORE_HOOK_SINK_INPUT_VOLUME_CHANGED],
                 PA_HOOK_LATE+10, (pa_hook_cb_t) sink_input_volume_changed_hook_cb, u);
 
@@ -707,6 +780,9 @@ void pa_droid_sink_set_voice_control(pa_sink* sink, bool enable) {
 
     } else {
         pa_assert(u->sink_input_volume_changed_hook_slot);
+
+        if (u->voice_virtual_stream)
+            destroy_voice_virtual_stream(u);
 
         pa_hook_slot_free(u->sink_input_volume_changed_hook_slot);
         u->sink_input_volume_changed_hook_slot = NULL;
@@ -849,6 +925,7 @@ pa_sink *pa_droid_sink_new(pa_module *m,
     dm_config_port *mix_port = NULL;
     dm_config_port *device_port = NULL;
     bool deferred_volume = false;
+    bool voice_virtual_stream = false;
     char *thread_name = NULL;
     pa_sink_new_data data;
     const char *module_id = NULL;
@@ -936,6 +1013,11 @@ pa_sink *pa_droid_sink_new(pa_module *m,
         goto fail;
     }
 
+    if (pa_modargs_get_value_boolean(ma, "voice_virtual_stream", &voice_virtual_stream) < 0) {
+        pa_log("Failed to parse voice_virtual_stream. Needs to be a boolean argument.");
+        goto fail;
+    }
+
     u = pa_xnew0(struct userdata, 1);
     u->core = m->core;
     u->module = m;
@@ -945,6 +1027,7 @@ pa_sink *pa_droid_sink_new(pa_module *m,
     pa_thread_mq_init(&u->thread_mq, m->core->mainloop, u->rtpoll);
     u->parameters = pa_hashmap_new_full(pa_idxset_string_hash_func, pa_idxset_string_compare_func,
                                         NULL, (pa_free_cb_t) parameter_free);
+    u->voice_virtual_stream = voice_virtual_stream;
     u->voice_property_key   = pa_xstrdup(pa_modargs_get_value(ma, "voice_property_key", DEFAULT_VOICE_CONTROL_PROPERTY_KEY));
     u->voice_property_value = pa_xstrdup(pa_modargs_get_value(ma, "voice_property_value", DEFAULT_VOICE_CONTROL_PROPERTY_VALUE));
     u->extra_devices_stack = dm_list_new();

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2026 Jolla Mobile Ltd
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/droid/droid-sink.h
+++ b/src/droid/droid-sink.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2013-2018 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/droid/droid-source.c
+++ b/src/droid/droid-source.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/droid/droid-source.h
+++ b/src/droid/droid-source.h
@@ -4,7 +4,7 @@
 /*
  * Copyright (C) 2013-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public

--- a/src/droid/meson.build
+++ b/src/droid/meson.build
@@ -53,11 +53,17 @@ module_sink = shared_module('module-droid-source' + droid_module_suffix,
   install_rpath : rpath_dirs,
 )
 
+module_card_sources = ['module-droid-card.c']
+module_card_extra_deps = []
+
+module_card_sources += 'droid-extcon.c'
+module_card_extra_deps += libudev_dep
+
 module_sink = shared_module('module-droid-card' + droid_module_suffix,
-  'module-droid-card.c',
+  module_card_sources,
   name_prefix : '',
   c_args : '-DPA_MODULE_NAME=module_droid_card' + droid_module_name_suffix,
-  dependencies : [droid_sink_dep, droid_source_dep, libdroid_util_dep],
+  dependencies : [droid_sink_dep, droid_source_dep, libdroid_util_dep] + module_card_extra_deps,
   install : true,
   install_dir : modlibexecdir,
   install_rpath : rpath_dirs,

--- a/src/droid/meson.build
+++ b/src/droid/meson.build
@@ -1,4 +1,4 @@
-droid_sink = library('droid-sink',
+droid_sink = library('droid-sink' + droid_module_suffix,
   ['droid-sink.c', 'droid-sink.h'],
   dependencies : libdroid_util_dep,
   pic : true,
@@ -15,7 +15,7 @@ droid_sink_dep = declare_dependency(
   include_directories : [configinc],
 )
 
-droid_source = library('droid-source',
+droid_source = library('droid-source' + droid_module_suffix,
   ['droid-source.c', 'droid-source.h'],
   dependencies : libdroid_util_dep,
   pic : true,
@@ -31,30 +31,32 @@ droid_source_dep = declare_dependency(
   include_directories : [configinc],
 )
 
-module_sink = shared_module('module-droid-sink',
+droid_module_name_suffix = droid_module_suffix.underscorify()
+
+module_sink = shared_module('module-droid-sink' + droid_module_suffix,
   'module-droid-sink.c',
   name_prefix : '',
-  c_args : '-DPA_MODULE_NAME=module_droid_sink',
+  c_args : '-DPA_MODULE_NAME=module_droid_sink' + droid_module_name_suffix,
   dependencies : [droid_sink_dep, libdroid_util_dep],
   install : true,
   install_dir : modlibexecdir,
   install_rpath : rpath_dirs,
 )
 
-module_sink = shared_module('module-droid-source',
+module_sink = shared_module('module-droid-source' + droid_module_suffix,
   'module-droid-source.c',
   name_prefix : '',
-  c_args : '-DPA_MODULE_NAME=module_droid_source',
+  c_args : '-DPA_MODULE_NAME=module_droid_source' + droid_module_name_suffix,
   dependencies : [droid_source_dep, libdroid_util_dep],
   install : true,
   install_dir : modlibexecdir,
   install_rpath : rpath_dirs,
 )
 
-module_sink = shared_module('module-droid-card',
+module_sink = shared_module('module-droid-card' + droid_module_suffix,
   'module-droid-card.c',
   name_prefix : '',
-  c_args : '-DPA_MODULE_NAME=module_droid_card',
+  c_args : '-DPA_MODULE_NAME=module_droid_card' + droid_module_name_suffix,
   dependencies : [droid_sink_dep, droid_source_dep, libdroid_util_dep],
   install : true,
   install_dir : modlibexecdir,

--- a/src/droid/meson.build
+++ b/src/droid/meson.build
@@ -59,6 +59,10 @@ module_card_extra_deps = []
 module_card_sources += 'droid-extcon.c'
 module_card_extra_deps += libudev_dep
 
+# TODO: build flag if needed
+module_card_sources += 'droid-extevdev.c'
+module_card_extra_deps += libevdev_dep
+
 module_sink = shared_module('module-droid-card' + droid_module_suffix,
   module_card_sources,
   name_prefix : '',

--- a/src/droid/meson.build
+++ b/src/droid/meson.build
@@ -59,9 +59,7 @@ module_card_extra_deps = []
 module_card_sources += 'droid-extcon.c'
 module_card_extra_deps += libudev_dep
 
-# TODO: build flag if needed
 module_card_sources += 'droid-extevdev.c'
-module_card_extra_deps += libevdev_dep
 
 module_sink = shared_module('module-droid-card' + droid_module_suffix,
   module_card_sources,

--- a/src/droid/meson.build
+++ b/src/droid/meson.build
@@ -60,6 +60,8 @@ module_card_sources += 'droid-extcon.c'
 module_card_extra_deps += libudev_dep
 
 module_card_sources += 'droid-extevdev.c'
+module_card_sources += 'droid-extusbdev.c'
+module_card_extra_deps += alsa_dep
 
 module_sink = shared_module('module-droid-card' + droid_module_suffix,
   module_card_sources,

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -81,6 +81,7 @@ PA_MODULE_USAGE(
         "config=<location for droid audio configuration> "
         "voice_property_key=<proplist key searched for sink-input that should control voice call volume> "
         "voice_property_value=<proplist value for the key for voice control sink-input> "
+        "voice_virtual_stream=<true/false> create virtual stream for voice call volume control (default false)"
         "options=<comma separated list of options to enable/disable>"
 );
 
@@ -107,6 +108,7 @@ static const char* const valid_modargs[] = {
     "config",
     "voice_property_key",
     "voice_property_value",
+    "voice_virtual_stream",
     /* DM_OPTIONS */
     NULL,
 };

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -65,6 +65,7 @@
 #include "droid-sink.h"
 #include "droid-source.h"
 #include "droid-extcon.h"
+#include "droid-extevdev.h"
 
 PA_MODULE_AUTHOR("Juho Hämäläinen");
 PA_MODULE_DESCRIPTION("Droid card");
@@ -152,6 +153,7 @@ struct userdata {
     pa_card_profile *real_profile;
 
     pa_droid_extcon *extcon;
+    pa_droid_extevdev *extevdev;
 
     pa_modargs *modargs;
     pa_card *card;
@@ -901,6 +903,11 @@ int pa__init(pa_module *m) {
     init_profile(u);
     u->extcon = pa_droid_extcon_new(m->core, u->card);
 
+    if (!u->extcon)
+        u->extevdev = pa_droid_extevdev_new(m->core, u->card);
+    else
+        u->extevdev = NULL;
+
     pa_card_put(u->card);
 
     return 0;
@@ -929,6 +936,9 @@ void pa__done(pa_module *m) {
 
         if (u->card && u->card->sources)
             pa_idxset_remove_all(u->card->sources, (pa_free_cb_t) pa_droid_source_free);
+
+        if (u->extevdev)
+            pa_droid_extevdev_free(u->extevdev);
 
         if (u->card)
             pa_card_free(u->card);

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -85,7 +85,7 @@ PA_MODULE_USAGE(
         "config=<location for droid audio configuration> "
         "voice_property_key=<proplist key searched for sink-input that should control voice call volume> "
         "voice_property_value=<proplist value for the key for voice control sink-input> "
-        "voice_virtual_stream=<true/false> create virtual stream for voice call volume control (default false)"
+        "voice_virtual_stream=<true/false> create virtual stream for voice call volume control (default true)"
         "options=<comma separated list of options to enable/disable>"
 );
 

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -821,10 +821,24 @@ static pa_hook_result_t port_availability_changed_hook_callback(void *hook_data,
         port->name, device,
         port->available == PA_AVAILABLE_YES ? "available" : "not available");
 
-    char * setparam = pa_sprintf_malloc("%s=%" PRIu32 "", verb, device);
-    pa_droid_set_parameters(u->hw_module, setparam);
 
-    pa_xfree(setparam);
+    pa_droid_port_data *data = PA_DEVICE_PORT_DATA(port);
+    #define PARAM_LEN (128)
+    char setparam[PARAM_LEN];
+    snprintf(setparam, PARAM_LEN, "%s=%" PRIu32, verb, device);
+
+    if (data->usb.card >= 0) {
+        size_t len = strlen(setparam);
+        char *w = setparam;
+        w += len;
+        snprintf(w, PARAM_LEN - len, ";card=%d", data->usb.card);
+        if (data->usb.device >= 0) {
+            size_t len2 = strlen(w);
+            w += len2;
+            snprintf(w, PARAM_LEN - len - len2, ";device=%d", data->usb.device);
+        }
+    }
+    pa_droid_set_parameters(u->hw_module, setparam);
 
     return PA_HOOK_OK;
 }

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -965,7 +965,8 @@ int pa__init(pa_module *m) {
     if (!u->extcon)
         u->extevdev = pa_droid_extevdev_new(u->card);
 
-    u->extusbdev = pa_droid_extusbdev_new(u->hw_module, u->card);
+    if (pa_droid_option(u->hw_module, DM_OPTION_USB_DEVICES))
+        u->extusbdev = pa_droid_extusbdev_new(u->hw_module, u->card);
 
     pa_module_hook_connect(u->module,
                            &u->module->core->hooks[PA_CORE_HOOK_PORT_AVAILABLE_CHANGED],

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Jolla Ltd.
+ * Copyright (C) 2013-2026 Jolla Mobile Ltd
  *
  * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
  *
@@ -68,6 +68,7 @@
 #include "droid-source.h"
 #include "droid-extcon.h"
 #include "droid-extevdev.h"
+#include "droid-extusbdev.h"
 
 PA_MODULE_AUTHOR("Juho Hämäläinen");
 PA_MODULE_DESCRIPTION("Droid card");
@@ -156,6 +157,7 @@ struct userdata {
 
     pa_droid_extcon *extcon;
     pa_droid_extevdev *extevdev;
+    pa_droid_extusbdev *extusbdev;
 
     pa_modargs *modargs;
     pa_card *card;
@@ -949,6 +951,8 @@ int pa__init(pa_module *m) {
     if (!u->extcon)
         u->extevdev = pa_droid_extevdev_new(u->card);
 
+    u->extusbdev = pa_droid_extusbdev_new(u->hw_module, u->card);
+
     pa_module_hook_connect(u->module,
                            &u->module->core->hooks[PA_CORE_HOOK_PORT_AVAILABLE_CHANGED],
                            PA_HOOK_NORMAL,
@@ -985,6 +989,9 @@ void pa__done(pa_module *m) {
 
         if (u->extevdev)
             pa_droid_extevdev_free(u->extevdev);
+
+        if (u->extusbdev)
+            pa_droid_extusbdev_free(u->extusbdev);
 
         if (u->card)
             pa_card_free(u->card);

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -23,6 +23,7 @@
 #include <config.h>
 #endif
 
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 
@@ -59,6 +60,7 @@
 //#include <droid/hardware/audio_policy.h>
 //#include <droid/system/audio_policy.h>
 
+#include <droid/conversion.h>
 #include <droid/droid-util.h>
 #include <droid/sllist.h>
 #include <droid/utils.h>
@@ -784,6 +786,47 @@ static int card_set_profile(pa_card *c, pa_card_profile *new_profile) {
     return 0;
 }
 
+static pa_hook_result_t port_availability_changed_hook_callback(void *hook_data,
+                                                                void *call_data,
+                                                                void *slot_data) {
+    pa_device_port *port = call_data;
+    struct userdata *u = slot_data;
+
+    /* Not meant for us */
+    if (port->card != u->card)
+        return PA_HOOK_OK;
+
+    /* Track only outputs for now. */
+    if (port->direction != PA_DIRECTION_OUTPUT)
+        return PA_HOOK_OK;
+
+    /* We don't track availability of this port. */
+    if (port->available == PA_AVAILABLE_UNKNOWN)
+        return PA_HOOK_OK;
+
+    const char * verb = port->available == PA_AVAILABLE_YES
+        ? AUDIO_PARAMETER_DEVICE_CONNECT
+        : AUDIO_PARAMETER_DEVICE_DISCONNECT;
+
+    uint32_t device;
+    if (!pa_droid_output_port_name_to_device(port->name, &device)) {
+        pa_log_warn("Can't notify Android of port '%s' as it's unknown.",
+            port->name);
+        return PA_HOOK_OK;
+    }
+
+    pa_log_info("Notifying Android of port '%s' (%" PRIu32 ") becoming %s.",
+        port->name, device,
+        port->available == PA_AVAILABLE_YES ? "available" : "not available");
+
+    char * setparam = pa_sprintf_malloc("%s=%" PRIu32 "", verb, device);
+    pa_droid_set_parameters(u->hw_module, setparam);
+
+    pa_xfree(setparam);
+
+    return PA_HOOK_OK;
+}
+
 
 int pa__init(pa_module *m) {
     struct userdata *u = NULL;
@@ -905,6 +948,11 @@ int pa__init(pa_module *m) {
 
     if (!u->extcon)
         u->extevdev = pa_droid_extevdev_new(u->card);
+
+    pa_module_hook_connect(u->module,
+                           &u->module->core->hooks[PA_CORE_HOOK_PORT_AVAILABLE_CHANGED],
+                           PA_HOOK_NORMAL,
+                           port_availability_changed_hook_callback, u);
 
     pa_card_put(u->card);
 

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2026 Jolla Mobile Ltd
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public
@@ -70,7 +70,7 @@
 #include "droid-extevdev.h"
 #include "droid-extusbdev.h"
 
-PA_MODULE_AUTHOR("Juho Hämäläinen");
+PA_MODULE_AUTHOR("Enni Hämäläinen");
 PA_MODULE_DESCRIPTION("Droid card");
 PA_MODULE_VERSION(PACKAGE_VERSION);
 PA_MODULE_USAGE(

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -64,6 +64,7 @@
 #include <droid/utils.h>
 #include "droid-sink.h"
 #include "droid-source.h"
+#include "droid-extcon.h"
 
 PA_MODULE_AUTHOR("Juho Hämäläinen");
 PA_MODULE_DESCRIPTION("Droid card");
@@ -147,6 +148,8 @@ struct userdata {
     pa_droid_card_data card_data;
 
     pa_card_profile *real_profile;
+
+    pa_droid_extcon *extcon;
 
     pa_modargs *modargs;
     pa_card *card;
@@ -894,6 +897,8 @@ int pa__init(pa_module *m) {
 
     pa_card_choose_initial_profile(u->card);
     init_profile(u);
+    u->extcon = pa_droid_extcon_new(m->core, u->card);
+
     pa_card_put(u->card);
 
     return 0;
@@ -916,6 +921,9 @@ void pa__done(pa_module *m) {
 
         if (u->card && u->card->sinks)
             pa_idxset_remove_all(u->card->sinks, (pa_free_cb_t) pa_droid_sink_free);
+
+        if (u->extcon)
+            pa_droid_extcon_free(u->extcon);
 
         if (u->card && u->card->sources)
             pa_idxset_remove_all(u->card->sources, (pa_free_cb_t) pa_droid_source_free);

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -904,9 +904,7 @@ int pa__init(pa_module *m) {
     u->extcon = pa_droid_extcon_new(m->core, u->card);
 
     if (!u->extcon)
-        u->extevdev = pa_droid_extevdev_new(m->core, u->card);
-    else
-        u->extevdev = NULL;
+        u->extevdev = pa_droid_extevdev_new(u->card);
 
     pa_card_put(u->card);
 

--- a/src/droid/module-droid-sink.c
+++ b/src/droid/module-droid-sink.c
@@ -69,6 +69,7 @@ static const char* const valid_modargs[] = {
     "deferred_volume",
     "voice_property_key",
     "voice_property_value",
+    "voice_virtual_stream",
     NULL,
 };
 

--- a/src/droid/module-droid-sink.c
+++ b/src/droid/module-droid-sink.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2018 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public
@@ -41,7 +41,7 @@
 #include <droid/conversion.h>
 #include "droid-sink.h"
 
-PA_MODULE_AUTHOR("Juho Hämäläinen");
+PA_MODULE_AUTHOR("Enni Hämäläinen");
 PA_MODULE_DESCRIPTION("Droid sink");
 PA_MODULE_USAGE("master_sink=<sink to connect to> "
                 "sink_name=<name of created sink>");

--- a/src/droid/module-droid-source.c
+++ b/src/droid/module-droid-source.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2022 Jolla Ltd.
  *
- * Contact: Juho Hämäläinen <juho.hamalainen@jolla.com>
+ * Contact: Enni Hämäläinen <enni.hamalainen@jolla.com>
  *
  * These PulseAudio Modules are free software; you can redistribute
  * it and/or modify it under the terms of the GNU Lesser General Public
@@ -40,7 +40,7 @@
 #include <droid/droid-util.h>
 #include "droid-source.h"
 
-PA_MODULE_AUTHOR("Juho Hämäläinen");
+PA_MODULE_AUTHOR("Enni Hämäläinen");
 PA_MODULE_DESCRIPTION("Droid source");
 PA_MODULE_USAGE("master_source=<source to connect to> "
                 "source_name=<name of created source>");


### PR DESCRIPTION
Merge useful commits from UBports. Most important ones regarding headphone and headset tracking. h2w implementation may be obsolete, but it's quite well isolated so if not needed it can be removed.

Implement USB device detection. Watch for sound devices in udev and only take into account devices that are under USB subsystem. Internal USB support is disabled by default, and it can be enabled with new option `usb_devices`.

Also some other useful things here and there.