### PR TITLE
Input accessory routing.

### DIFF
--- a/src/common/conversion.c
+++ b/src/common/conversion.c
@@ -225,6 +225,10 @@ bool pa_droid_input_port_name(audio_devices_t value, const char **to_str) {
     return string_convert_num_to_str(string_conversion_table_input_device_fancy, (uint32_t) value, to_str);
 }
 
+bool pa_droid_input_port_name_to_device(const char *str, audio_devices_t *to_value) {
+    return string_convert_str_to_num(string_conversion_table_input_device_fancy, str, to_value);
+}
+
 static int parse_list(const struct string_conversion *table,
                       const char *separator,
                       const char *str,

--- a/src/common/include/droid/conversion.h
+++ b/src/common/include/droid/conversion.h
@@ -81,6 +81,7 @@ bool pa_input_device_default_audio_source(audio_devices_t input_device, audio_so
 bool pa_droid_output_port_name(audio_devices_t value, const char **to_str);
 bool pa_droid_output_port_name_to_device(const char *str, audio_devices_t *to_value);
 bool pa_droid_input_port_name(audio_devices_t value, const char **to_str);
+bool pa_droid_input_port_name_to_device(const char *str, audio_devices_t *to_value);
 
 int pa_conversion_parse_list(pa_conversion_string_t type, const char *separator,
                              const char *str, uint32_t *dst, char **unknown_entries);

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -964,13 +964,6 @@ int pa__init(pa_module *m) {
 
     pa_card_choose_initial_profile(u->card);
     init_profile(u);
-    u->extcon = pa_droid_extcon_new(m->core, u->card);
-
-    if (!u->extcon)
-        u->extevdev = pa_droid_extevdev_new(u->card);
-
-    if (pa_droid_option(u->hw_module, DM_OPTION_USB_DEVICES))
-        u->extusbdev = pa_droid_extusbdev_new(u->hw_module, u->card);
 
     pa_module_hook_connect(u->module,
                            &u->module->core->hooks[PA_CORE_HOOK_PORT_AVAILABLE_CHANGED],
@@ -978,6 +971,14 @@ int pa__init(pa_module *m) {
                            port_availability_changed_hook_callback, u);
 
     pa_card_put(u->card);
+
+    u->extcon = pa_droid_extcon_new(m->core, u->card);
+
+    if (!u->extcon)
+        u->extevdev = pa_droid_extevdev_new(u->card);
+
+    if (pa_droid_option(u->hw_module, DM_OPTION_USB_DEVICES))
+        u->extusbdev = pa_droid_extusbdev_new(u->hw_module, u->card);
 
     return 0;
 

--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -798,10 +798,6 @@ static pa_hook_result_t port_availability_changed_hook_callback(void *hook_data,
     if (port->card != u->card)
         return PA_HOOK_OK;
 
-    /* Track only outputs for now. */
-    if (port->direction != PA_DIRECTION_OUTPUT)
-        return PA_HOOK_OK;
-
     /* We don't track availability of this port. */
     if (port->available == PA_AVAILABLE_UNKNOWN)
         return PA_HOOK_OK;
@@ -811,13 +807,21 @@ static pa_hook_result_t port_availability_changed_hook_callback(void *hook_data,
         : AUDIO_PARAMETER_DEVICE_DISCONNECT;
 
     uint32_t device;
-    if (!pa_droid_output_port_name_to_device(port->name, &device)) {
-        pa_log_warn("Can't notify Android of port '%s' as it's unknown.",
-            port->name);
-        return PA_HOOK_OK;
+    if (port->direction == PA_DIRECTION_OUTPUT) {
+        if (!pa_droid_output_port_name_to_device(port->name, &device)) {
+            pa_log_warn("Can't notify audio hal of output port '%s' as it's unknown.",
+                        port->name);
+            return PA_HOOK_OK;
+        }
+    } else {
+        if (!pa_droid_input_port_name_to_device(port->name, &device)) {
+            pa_log_warn("Can't notify audio hal of input port '%s' as it's unknown.",
+                        port->name);
+            return PA_HOOK_OK;
+        }
     }
 
-    pa_log_info("Notifying Android of port '%s' (%" PRIu32 ") becoming %s.",
+    pa_log_info("Notifying audio hal of port '%s' (%" PRIu32 ") becoming %s.",
         port->name, device,
         port->available == PA_AVAILABLE_YES ? "available" : "not available");
 


### PR DESCRIPTION
When headset devices are connecting we need to set parameters
for the input port device as well, otherwise routing to the
input doesn't work.